### PR TITLE
Update 0.9.4-ConfigKeys.php

### DIFF
--- a/configs/0.9.4-ConfigKeys.php
+++ b/configs/0.9.4-ConfigKeys.php
@@ -530,7 +530,8 @@ $keys = array(
         'type' => 'array',
         'default' => array(
             'google_ad_',
-            'RSPEAK_'
+            'RSPEAK_',
+            'mfunc'
         )
     ),
     'minify.css.enable' => array(


### PR DESCRIPTION
Adds mfunc to the default ignore list so those who have the premium plugin and are using fragment caching won't need to exclude it on their own.