### PR TITLE
AMP support

### DIFF
--- a/lib/W3/Plugin/Minify.php
+++ b/lib/W3/Plugin/Minify.php
@@ -133,6 +133,12 @@ class W3_Plugin_Minify extends W3_Plugin {
             if ($this->can_minify2($buffer)) {
                 $this->minify_helpers = new _W3_MinifyHelpers($this->_config);
 
+                if( function_exists('is_amp_endpoint') && is_amp_endpoint() ) {
+                    $add_script_and_style = false;
+                } else {
+                    $add_script_and_style = true;
+                }
+
                 /**
                  * Replace script and style tags
                  */


### PR DESCRIPTION
Actually, in AMP pages generated by AMP Plugin, W3TC still prints the minfied and concatenate CSS and JS but it shouldn't. It makes AMP validation to fail.

see: https://wordpress.org/support/topic/disable-on-amp-pages?replies=23

Closes #8
