### PR TITLE
Amiga

### DIFF
--- a/configs/0.9.2.10-ConfigKeys.php
+++ b/configs/0.9.2.10-ConfigKeys.php
@@ -780,7 +780,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/configs/0.9.2.11-ConfigKeys.php
+++ b/configs/0.9.2.11-ConfigKeys.php
@@ -780,7 +780,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/configs/0.9.2.6-ConfigKeys.php
+++ b/configs/0.9.2.6-ConfigKeys.php
@@ -764,7 +764,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/configs/0.9.2.7-ConfigKeys.php
+++ b/configs/0.9.2.7-ConfigKeys.php
@@ -764,7 +764,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/configs/0.9.2.8-ConfigKeys.php
+++ b/configs/0.9.2.8-ConfigKeys.php
@@ -764,7 +764,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/configs/0.9.2.9-ConfigKeys.php
+++ b/configs/0.9.2.9-ConfigKeys.php
@@ -764,7 +764,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/configs/0.9.3-ConfigKeys.php
+++ b/configs/0.9.3-ConfigKeys.php
@@ -780,7 +780,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/configs/0.9.4-ConfigKeys.php
+++ b/configs/0.9.4-ConfigKeys.php
@@ -785,7 +785,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff,*.less'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff;*.less'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -784,7 +784,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff,*.woff2,*.less'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff;*.woff2;*.less'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',


### PR DESCRIPTION
Changed "," to ";" in the ConfigKeys files for the few ending file types.  Seems like someone meant to make it ";" but accidentally used "," instead.  Unless it was intentional to, for example, group *.otf, *.woff, *.woff2, *.less (found in ConfigKeys.php) as one file group type instead of as separate file types.  I have to figure the original intention was as separate file types, and hence, the use of a ";" for each instead.