### PR TITLE
Deprecated the "Allow, Deny, and Order" directives

### DIFF
--- a/lib/W3/PgCacheAdminEnvironment.php
+++ b/lib/W3/PgCacheAdminEnvironment.php
@@ -1141,7 +1141,12 @@ class W3_PgCacheAdminEnvironment {
 
             // allow to read files by apache if they are blocked at some level above
             $rules .= "<Files ~ \"\.(html|html_gzip|xml|xml_gzip)$\">\n";
-            $rules .= "  Allow from all\n";
+            $rules .= "  <IfModule mod_authz_host.c>\n";
+            $rules .= "    Require all granted\n";
+            $rules .= "  </IfModule>\n";
+            $rules .= "  <IfModule !mod_authz_host.c>\n";
+            $rules .= "    Allow from all\n";
+            $rules .= "  </IfModule>\n";
             $rules .= "</Files>\n";
 
             if (!$etag) {


### PR DESCRIPTION
**SIDE NOTE**: see https://github.com/szepeviktor/w3-total-cache-fixed/pull/40 that fix and issue introduced by this pr.

Apache v2.4+ has deprecated the "Allow, Deny, and Order" directives in .htaccess, in favor of the "Require" directive.  Such servers would now be forced to load the "mod_access_compat" module to regain "Allow, Deny, and Order" (unlike pre-2.4).    For w3tc's "Enable Compatibility Mode" to function correctly on servers that have upgraded i've put in the appropriate module condition check and corresponding directive.


