### PR TITLE
Load Balancer Issue

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -248,6 +248,7 @@ function w3_is_https() {
     switch (true) {
         case (isset($_SERVER['HTTPS']) && w3_to_boolean($_SERVER['HTTPS'])):
         case (isset($_SERVER['SERVER_PORT']) && (int) $_SERVER['SERVER_PORT'] == 443):
+        case (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'):
             return true;
     }
 


### PR DESCRIPTION
For ssl websites behind load balancers (e.g. Amazon's AWS) or reverse proxies that support HTTP_X_FORWARDED_PROTO this fixes an issue of not being recognized as using https.

It should be noted that Wordpress devs makes mention of this in [their docs](https://codex.wordpress.org/Function_Reference/is_ssl#Notes) saying that sites in this situation can simply add a similar line to their wp-config.php file, but i figure most people won't realize this and just assume its a w3tc bug.  Better to just have it built in.