### PR TITLE
Selectively emptying the Redis cache

### DIFF
--- a/inc/options/dashboard.php
+++ b/inc/options/dashboard.php
@@ -15,6 +15,7 @@
         <?php echo $this->nonce_field('w3tc'); ?>
         <input id="flush_all" class="button" type="submit" name="w3tc_flush_all" value="<?php _e('empty all caches', 'w3-total-cache') ?>"<?php if (! $can_empty_memcache && ! $can_empty_opcode && ! $can_empty_file && ! $can_empty_varnish): ?> disabled="disabled"<?php endif; ?> /> <?php _e('at once or', 'w3-total-cache') ?>
         <input class="button" type="submit" name="w3tc_flush_memcached" value="<?php _e('empty only the memcached cache(s)', 'w3-total-cache') ?>"<?php if (! $can_empty_memcache): ?> disabled="disabled"<?php endif; ?> /> <?php _e('or', 'w3-total-cache') ?>
+        <input class="button" type="submit" name="w3tc_flush_redis" value="<?php _e('empty only the redis cache(s)', 'w3-total-cache') ?>"<?php if (! $can_empty_redis): ?> disabled="disabled"<?php endif; ?> /> <?php _e('or', 'w3-total-cache') ?>
         <input class="button" type="submit" name="w3tc_flush_opcode" value="<?php _e('empty only the opcode cache', 'w3-total-cache') ?>"<?php if (! $can_empty_opcode): ?> disabled="disabled"<?php endif; ?> /> <?php _e('or', 'w3-total-cache') ?>
         <?php if ($can_empty_apc_system): ?>
         <input class="button" type="submit" name="w3tc_flush_apc_system" value="<?php _e('empty only the APC system cache', 'w3-total-cache') ?>"<?php if (! $can_empty_apc_system): ?> disabled="disabled"<?php endif; ?> /> <?php _e('or', 'w3-total-cache') ?>

--- a/lib/W3/AdminActions/FlushActionsAdmin.php
+++ b/lib/W3/AdminActions/FlushActionsAdmin.php
@@ -291,6 +291,15 @@ class W3_AdminActions_FlushActionsAdmin {
     }
 
     /**
+     * Flush Redis cache
+     *
+     * @return void
+     */
+    function flush_redis() {
+        $this->flush('redis');
+    }
+    
+    /**
      * Flush APC cache
      *
      * @return void
@@ -329,6 +338,7 @@ class W3_AdminActions_FlushActionsAdmin {
      */
     function flush_all($flush_cf = true) {
         $this->flush_memcached();
+        $this->flush_redis();
         $this->flush_opcode();
         $this->flush_file();
         $this->flush_browser_cache();

--- a/lib/W3/AdminActions/FlushActionsAdmin.php
+++ b/lib/W3/AdminActions/FlushActionsAdmin.php
@@ -42,6 +42,18 @@ class W3_AdminActions_FlushActionsAdmin {
     }
 
     /**
+     * Flush redis cache action
+     *
+     * @return void
+     */
+    function action_flush_redis() {
+        $this->flush_redis();
+
+        w3_admin_redirect(array(
+            'w3tc_note' => 'flush_redis'
+        ), true);
+    }
+    /**
      * Flush opcode caches action
      *
      * @return void

--- a/lib/W3/ModuleStatus.php
+++ b/lib/W3/ModuleStatus.php
@@ -81,6 +81,17 @@ class W3_ModuleStatus {
     /**
      * @return bool
      */
+    public function can_empty_redis() {
+        return $this->_enabled_module_uses_engine('pgcache', 'redis')
+                || $this->_enabled_module_uses_engine('dbcache', 'redis')
+                || $this->_enabled_module_uses_engine('objectcache', 'redis')
+                || $this->_enabled_module_uses_engine('minify', 'redis')
+                || $this->_enabled_module_uses_engine('fragmentcache', 'redis');
+    }
+
+    /**
+     * @return bool
+     */
     public function can_empty_opcode() {
         return $this->_enabled_module_uses_engine('pgcache', $this->_opcode_engines)
                 || $this->_enabled_module_uses_engine('dbcache', $this->_opcode_engines)

--- a/lib/W3/Plugin/TotalCache.php
+++ b/lib/W3/Plugin/TotalCache.php
@@ -217,6 +217,8 @@ class W3_Plugin_TotalCache extends W3_Plugin {
 
             $can_empty_memcache = $modules->can_empty_memcache();
 
+            $can_empty_redis = $modules->can_empty_redis();
+            
             $can_empty_opcode = $modules->can_empty_opcode();
 
             $can_empty_file = $modules->can_empty_file();
@@ -245,7 +247,7 @@ class W3_Plugin_TotalCache extends W3_Plugin {
                 );
             }
 
-            if ($can_empty_file && ($can_empty_opcode || $can_empty_memcache)) {
+            if ($can_empty_file && ($can_empty_opcode || $can_empty_memcache || $can_empty_redis)) {
                 $menu_items[] = array(
                     'id' => 'w3tc-flush-file',
                     'parent' => 'w3tc-empty-caches',
@@ -254,7 +256,7 @@ class W3_Plugin_TotalCache extends W3_Plugin {
                 );
             }
 
-            if ($can_empty_opcode && ($can_empty_file || $can_empty_memcache)) {
+            if ($can_empty_opcode && ($can_empty_file || $can_empty_memcache || $can_empty_redis)) {
                 $menu_items[] = array(
                     'id' => 'w3tc-flush-opcode',
                     'parent' => 'w3tc-empty-caches',
@@ -263,12 +265,21 @@ class W3_Plugin_TotalCache extends W3_Plugin {
                 );
             }
 
-            if ($can_empty_memcache && ($can_empty_file || $can_empty_opcode)) {
+            if ($can_empty_memcache && ($can_empty_file || $can_empty_opcode || $can_empty_redis)) {
                 $menu_items[] = array(
                     'id' => 'w3tc-flush-memcached',
                     'parent' => 'w3tc-empty-caches',
                     'title' => __('Empty Memcached Cache(s)', 'w3-total-cache'),
                     'href' => wp_nonce_url(admin_url('admin.php?page=w3tc_dashboard&amp;w3tc_flush_memcached'), 'w3tc')
+                );
+            }
+
+            if ($can_empty_redis && ($can_empty_file || $can_empty_opcode || $can_empty_memcache)) {
+                $menu_items[] = array(
+                    'id' => 'w3tc-flush-redis',
+                    'parent' => 'w3tc-empty-caches',
+                    'title' => __('Empty Redis Cache(s)', 'w3-total-cache'),
+                    'href' => wp_nonce_url(admin_url('admin.php?page=w3tc_dashboard&amp;w3tc_flush_redis'), 'w3tc')
                 );
             }
 

--- a/lib/W3/Plugin/TotalCacheAdmin.php
+++ b/lib/W3/Plugin/TotalCacheAdmin.php
@@ -508,6 +508,7 @@ ul.w3tc-incomp-plugins li div{
             'config_save' => __('Plugin configuration successfully updated.', 'w3-total-cache'),
             'flush_all' => __('All caches successfully emptied.', 'w3-total-cache'),
             'flush_memcached' => __('Memcached cache(s) successfully emptied.', 'w3-total-cache'),
+            'flush_redis' => __('Redis cache(s) successfully emptied.', 'w3-total-cache'),
             'flush_opcode' => __('Opcode cache(s) successfully emptied.', 'w3-total-cache'),
             'flush_apc_system' => __('APC system cache successfully emptied', 'w3-total-cache'),
             'flush_file' => __('Disk cache(s) successfully emptied.', 'w3-total-cache'),

--- a/lib/W3/UI/DashboardAdminView.php
+++ b/lib/W3/UI/DashboardAdminView.php
@@ -34,6 +34,8 @@ class W3_UI_DashboardAdminView extends W3_UI_PluginView {
 
         $can_empty_memcache = $module_status->can_empty_memcache();
 
+        $can_empty_redis = $module_status->can_empty_redis();
+        
         $can_empty_opcode = $module_status->can_empty_opcode();
 
         $can_empty_apc_system = $module_status->can_empty_apc_system();


### PR DESCRIPTION
Added the required code to selectively clear the redis cache if other cache types are enabled.
Redis will now also be flushed when "Empty All Caches" is clicked.