### PR TITLE
memcached library support

### DIFF
--- a/inc/lightbox/self_test.php
+++ b/inc/lightbox/self_test.php
@@ -117,6 +117,15 @@ w3_require_once(W3TC_INC_DIR . '/functions/rule.php');
         </li>
 
         <li>
+            <?php _e('Memcached extension:', 'w3-total-cache'); ?>
+            <?php if (class_exists('Memcached')): ?>
+            <code><?php _e('Installed', 'w3-total-cache'); ?></code>
+            <?php else: ?>
+            <code><?php _e('Not installed', 'w3-total-cache'); ?></code>
+            <?php endif; ?>
+        </li>
+        
+        <li>
             <?php _e('Redis Extension','w3-total-cache'); ?>
             <?php if(class_exists('Redis')):?>
             <code><?php _e('Installed','w3-total-cache'); ?></code>

--- a/lib/W3/UI/GeneralAdminView.php
+++ b/lib/W3/UI/GeneralAdminView.php
@@ -46,7 +46,7 @@ class W3_UI_GeneralAdminView extends W3_UI_PluginView {
         $check_xcache = function_exists('xcache_set');
         $check_wincache = function_exists('wincache_ucache_set');
         $check_curl = function_exists('curl_init');
-        $check_memcached = class_exists('Memcache');
+        $check_memcached = class_exists('Memcache') || class_exists('Memcached');
         $check_redis = class_exists('Redis');
         $check_ftp = function_exists('ftp_connect');
         $check_tidy = class_exists('tidy');


### PR DESCRIPTION
PHP supports two memcached libraries: **memcache** and (the poorly named) **memcached**.  w3tc only supports the _memcache_ library extension.  Because the memcache library is still not supported under  php7 this leaves the newer _memcached_ library as the only option to communicate with a memcached server.  As such, this update checks for and makes use of the php memcached extension library, if available, and in so doing now provides php7 support for a memcached server.  w3tc's original memcache extension code is still there (untouched) and fully working (if the extension gets loaded), of course.