### PR TITLE
w3c validation issue for css files

### DIFF
--- a/lib/W3/Plugin/Minify.php
+++ b/lib/W3/Plugin/Minify.php
@@ -651,7 +651,7 @@ class W3_Plugin_Minify extends W3_Plugin {
         } elseif ($import && !$use_style) {
             return "@import url(\"" . $url . "\");\r\n";
         }else {
-            return "<link rel=\"stylesheet\" type=\"text/css\" href=\"" . str_replace('&', '&amp;', $url) . "\" media=\"all\" />\r\n";
+            return "<link rel=\"stylesheet\" property=\"stylesheet\" type=\"text/css\" href=\"" . str_replace('&', '&amp;', $url) . "\" media=\"all\" />\r\n";
         }
     }
 


### PR DESCRIPTION
Minifying external css files inside the html body results in a W3C validation error.  This fixes that problem.

**SIDE NOTE**: read https://github.com/szepeviktor/w3-total-cache-fixed/pull/65
