### PR TITLE
Url Parsing Fix (for Page Cache Flushing) & SSL Caching Fix

### DIFF
--- a/lib/W3/PgCache.php
+++ b/lib/W3/PgCache.php
@@ -572,6 +572,15 @@ class W3_PgCache {
             return false;
         }
 
+        /**
+         * Don't cache SSL
+         */
+        if (!$this->_config->get_boolean('pgcache.cache.ssl') && w3_is_https()) {
+            $this->cache_reject_reason = 'Page is SSL';
+
+            return false;
+        }
+        
         return true;
     }
 

--- a/lib/W3/PgCache.php
+++ b/lib/W3/PgCache.php
@@ -965,8 +965,10 @@ class W3_PgCache {
         $encryption = '', $compression = '', $content_type = '', $request_uri = '') {
 
         if ($request_uri){
-            $is_ssl_request = ( strtolower(substr($request_uri, 0, 8)) == 'https://' );
-            $key = substr( $request_uri, $is_ssl_request ? 8 : 7 );
+            $uri = parse_url($request_uri);
+		  $key =  $uri["host"].
+		          (isset($uri["path"])?$uri["path"]:"").
+		          (isset($uri["query"])?"?".$uri["query"]:"");
         } else {
             $key = $this->_request_host . $this->_request_uri;
 		}


### PR DESCRIPTION
Corrects a url parsing flaw when flushing a page.  It now is able to properly strip out anomalies like a port #. #41 

Fixes a bug where SSL pages were always getting cached despite the "Cache SSL (https) Requests" option being unchecked (disabled).  This fix will only allow SSL pages to be cached when said option is checked on (enabled). #43 