### PR TITLE
Fix for Role Removal from $current_user

### DIFF
--- a/lib/W3/Plugin/Cdn.php
+++ b/lib/W3/Plugin/Cdn.php
@@ -933,7 +933,7 @@ class W3_Plugin_Cdn extends W3_Plugin {
         if (empty($roles))
             return true;
 
-        $role = array_shift( $current_user->roles );
+        $role = $current_user->roles[0];
 
         if (in_array($role, $roles)) {
             return false;

--- a/lib/W3/Plugin/NewRelic.php
+++ b/lib/W3/Plugin/NewRelic.php
@@ -111,7 +111,7 @@ class W3_Plugin_NewRelic extends W3_Plugin{
         if (empty($roles))
             return false;
 
-        $role = array_shift( $current_user->roles );
+        $role = $current_user->roles[0];
 
         if (in_array($role, $roles)) {
             return false;

--- a/lib/W3/Plugin/TotalCache.php
+++ b/lib/W3/Plugin/TotalCache.php
@@ -739,15 +739,19 @@ class W3_Plugin_TotalCache extends W3_Plugin {
     function check_login_action($logged_in_cookie = false, $expire = ' ', $expiration = 0, $user_id = 0, $action = 'logged_out') {
         $current_user = wp_get_current_user();
         if (isset($current_user->ID) && !$current_user->ID)
+        {
+            if ($user_id == 0) return;
             $user_id = new WP_User($user_id);
+        }
         else
             $user_id = $current_user;
+
         if (is_string($user_id->roles)) {
             $role = $user_id->roles;
         } elseif (!is_array($user_id->roles)) {
             return;
         } else {
-            $role = array_shift( $user_id->roles );
+            $role = $user_id->roles[0];
         }
 
         $role_hash = md5(NONCE_KEY . $role);


### PR DESCRIPTION
When the $current_user is logged in (meaning, they have a user id > 0) they're always guaranteed to have a designated "role".  With that in mind one can do away with the ill-advised array_shift() function call, which was unintentionally stripping the active $current_user's role globally, and simply just lookup the 1st element in its "roles" array. #42 