### PR TITLE
Minify Notification Update

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -20,6 +20,7 @@ define('W3TC_SUPPORT_US_TIMEOUT', 2592000);
 define('W3TC_SUPPORT_REQUEST_URL', 'https://www.w3-edge.com/w3tc/support/');
 define('W3TC_TRACK_URL', 'https://www.w3-edge.com/w3tc/track/');
 define('W3TC_MAILLINGLIST_SIGNUP_URL', 'https://www.w3-edge.com/w3tc/emailsignup/');
+define('W3TC_MINIFY_VER_ID', '#MVER#');
 define('NEWRELIC_SIGNUP_URL', 'http://bit.ly/w3tc-partner-newrelic-signup');
 define('MAXCDN_SIGNUP_URL', 'http://bit.ly/w3tc-cdn-maxcdn-create-account');
 define('MAXCDN_AUTHORIZE_URL', 'http://bit.ly/w3tc-cdn-maxcdn-authorize');

--- a/lib/W3/CacheFlushLocal.php
+++ b/lib/W3/CacheFlushLocal.php
@@ -87,6 +87,7 @@ class W3_CacheFlushLocal {
      */
     function pgcache_flush() {
         do_action('w3tc_pgcache_flush');
+        $this->pgcache_flush_minify_version_change();
         $pgcacheflush = w3_instance('W3_PgCacheFlush');
         return $pgcacheflush->flush();
     }
@@ -389,5 +390,12 @@ class W3_CacheFlushLocal {
         /** @var $pgcache W3_Plugin_PgCacheAdmin */
         $pgcache = w3_instance('W3_Plugin_PgCacheAdmin');
         return $pgcache->prime_post($post_id);
+    }
+    
+    function pgcache_flush_minify_version_change() {
+        $config_admin = w3_instance('W3_ConfigAdmin');
+        $cur_min_ver = $config_admin->get_integer('minify.version');
+        $config_admin->set('minify.version', ++$cur_min_ver);
+        $config_admin->save();
     }
 }

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -593,7 +593,8 @@ $keys = array(
         'type' => 'array',
         'default' => array(
             'google_ad_',
-            'RSPEAK_'
+            'RSPEAK_',
+            'mfunc'
         )
     ),
     'minify.css.enable' => array(
@@ -1979,6 +1980,10 @@ $keys_admin = array(
         'type' => 'int',
         'default' => 0,
         'master_only' => 'true'
+    ),
+    'minify.version' => array(
+        'type' => 'integer',
+        'default' => 0
     )
 );
 


### PR DESCRIPTION
This resolves a long standing issue where some people were seeing: _"Recently an error occurred while creating the CSS / JS minify cache: File "XXX" doesn't exist"_ endlessly for plugins and themes they thought
were removed long ago.  What causes this is that someone or some thing is attempting to retrieve an old minified file.  This can happen through bot requests, not clearing a site's page cache, stale client-side browser caches, etc. 

This update implements very closely what @charlesLF is talking about [here](https://github.com/szepeviktor/fix-w3tc/issues/13#issuecomment-247115768).

For more details about this issue please refer to #13