### PR TITLE
Fixed incorrect labels on Redis settings page.

### DIFF
--- a/inc/options/dbcache.php
+++ b/inc/options/dbcache.php
@@ -47,7 +47,7 @@
             <?php endif; ?>
             <?php if ($this->_config->get_string('dbcache.engine') == 'redis'): ?>
             <tr>
-                <th><label for="redis_server"><?php w3_e_config_label('dbcache.memcached.servers') ?></label></th>
+                <th><label for="redis_server"><?php w3_e_config_label('dbcache.redis.server') ?></label></th>
                 <td>
                     <input id="redis_server" type="text"
                         name="dbcache.redis.server"

--- a/inc/options/objectcache.php
+++ b/inc/options/objectcache.php
@@ -36,7 +36,7 @@
             <?php endif; ?>
             <?php if ($this->_config->get_string('objectcache.engine') == 'redis'): ?>
             <tr>
-                <th><label for="redis_server"><?php w3_e_config_label('objectcache.memcached.servers') ?></label></th>
+                <th><label for="redis_server"><?php w3_e_config_label('objectcache.redis.server') ?></label></th>
                 <td>
                     <input id="redis_server" type="text"
                         name="objectcache.redis.server"

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -257,7 +257,7 @@
             <?php endif; ?>
             <?php if ($this->_config->get_string('pgcache.engine') == 'redis'): ?>
             <tr>
-                <th><label for="redis_server"><?php w3_e_config_label('pgcache.memcached.servers') ?></label></th>
+                <th><label for="redis_server"><?php w3_e_config_label('pgcache.redis.server') ?></label></th>
                 <td>
                     <input id="redis_server" type="text"
                         name="pgcache.redis.server"


### PR DESCRIPTION
This is a fix for the incorrect labels showing on the Redis page. The labels were referencing the memcached strings instead of the Redis ones.
