### PR TITLE
Use standard WP function remove_all_filters()

### DIFF
--- a/inc/functions/plugin.php
+++ b/inc/functions/plugin.php
@@ -327,8 +327,7 @@ function w3tc_fragmentcache_start($id, $group = '', $hook = '') {
     } else {
         echo $fragment;
         if ($hook) {
-            global $wp_filter;
-            $wp_filter[$hook] = array();
+            remove_all_filters($hook);
         }
         return true;
     }


### PR DESCRIPTION
Use standard WP function remove_all_filters()

Fix for https://github.com/szepeviktor/fix-w3tc/issues/56