### PR TITLE
PageSpeeds update & Dashboard Buy Now/Licensing Widgets Removed

### DIFF
--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -573,28 +573,6 @@
         foreach($custom_areas as $area)
             do_action("{$this->_page}_boxarea_{$area['id']}");
         ?>
-        <?php if ($licensing_visible): ?>
-            <?php echo $this->postbox_header(__('Licensing', 'w3-total-cache'), '', 'licensing'); ?>
-            <table class="form-table">
-                    <tr>
-                        <th>
-                            <label for="plugin_license_key"><?php w3_e_config_label('plugin.license_key', 'general') ?></label>
-                        </th>
-                        <td>
-                            <input id ="plugin_license_key" name="plugin.license_key" type="text" value="<?php echo esc_attr($this->_config->get_string('plugin.license_key'))?>" size="45"/>
-                            <input id="plugin_license_key_verify" type="button" value="<?php _e('Verify license key', 'w3-total-cache') ?>"/><br />
-                            <span class="description"><?php printf(__('Please enter the license key provided you received after %s.', 'w3-total-cache'), '<a class="button-buy-plugin" href="' . EDD_W3EDGE_STORE_URL_PLUGIN .'">' . __('upgrading', 'w3-total-cache') . '</a>')?></span>
-                        </td>
-                    </tr>
-                
-            </table>
-            <p class="submit">
-                <?php echo $this->nonce_field('w3tc'); ?>
-                <input type="submit" id="w3tc_save_options_licensing" name="w3tc_save_options" class="w3tc-button-save button-primary" value="Save all settings" />
-            </p>
-            <?php echo $this->postbox_footer(); ?>
-        <?php endif ?>
-        
         <?php echo $this->postbox_header(__('Miscellaneous', 'w3-total-cache'), '', 'miscellaneous'); ?>
         <table class="form-table">
             <tr>
@@ -610,6 +588,13 @@
                     <input id="widget_pagespeed_key" type="text" name="widget.pagespeed.key" value="<?php echo esc_attr($this->_config->get_string('widget.pagespeed.key')); ?>" size="60" /><br />
                     <span class="description"><?php _e('To acquire an <acronym title="Application Programming Interface">API</acronym> key, visit the <a href="https://code.google.com/apis/console" target="_blank"><acronym title="Application Programming Interface">API</acronym>s Console</a>. Go to the Project Home tab, activate the Page Speed Online <acronym title="Application Programming Interface">API</acronym>, and accept the Terms of Service.
                     Then go to the <acronym title="Application Programming Interface">API</acronym> Access tab. The <acronym title="Application Programming Interface">API</acronym> key is in the Simple <acronym title="Application Programming Interface">API</acronym> Access section.', 'w3-total-cache'); ?></span>
+                </td>
+            </tr>
+            <tr>
+                <th><label for="widget_pagespeed_key"><?php w3_e_config_label('widget.pagespeed.key.restrict.referrer', 'general') ?></label></th>
+                <td>
+                    <input type="text" id="widget_pagespeed_key_restrict_referrer" name="widget.pagespeed.key.restrict.referrer" value="<?php echo esc_attr($this->_config->get_string('widget.pagespeed.key.restrict.referrer')); ?>" size="60" /><br>
+                    <span class="description">Although not required, to prevent unauthorized use and quota theft, you have the option to restrict your key using a designated HTTP referrer. If you decide to use it, you will need to set this referrer within the API Console's "Http Referrers (web sites)" key restriction area (under Credentials).</span>
                 </td>
             </tr>
             <?php if (is_network_admin()): ?>

--- a/inc/widget/pagespeed_control.php
+++ b/inc/widget/pagespeed_control.php
@@ -7,3 +7,10 @@
 </p>
 <p>To acquire an <acronym title="Application Programming Interface">API</acronym> key, visit the <a href="https://code.google.com/apis/console" target="_blank">APIs Console</a>. Go to the Project Home tab, activate the Page Speed Online <acronym title="Application Programming Interface">API</acronym>, and accept the Terms of Service.</p>
 <p>Then go to the <acronym title="Application Programming Interface">API</acronym> Access tab. The <acronym title="Application Programming Interface">API</acronym> key is in the Simple <acronym title="Application Programming Interface">API</acronym> Access section.</p>
+<p>
+	<label>
+        Key Restriction (Referrer):
+         <input type="text" name="widget_pagespeed_key_restrict_referrer" value="<?php echo esc_attr($this->_config->get_string('widget.pagespeed.key.restrict.referrer')); ?>" size="40" class="w3tc-ignore-change" />
+    </label>
+</p>
+<p>Although not required, to prevent unauthorized use and quota theft, you have the option to restrict your key using a designated HTTP referrer. If you decide to use it, you will need to set this referrer within the API Console's "Http Referrers (web sites)" key restriction area (under Credentials).</p>

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -1600,7 +1600,10 @@ $keys = array(
         'type' => 'string',
         'default' => ''
     ),
-
+    'widget.pagespeed.key.restrict.referrer' => array(
+        'type' => 'string',
+        'default' => ''
+    ),
     'notes.wp_content_changed_perms' => array(
         'type' => 'boolean',
         'default' => true

--- a/lib/W3/PageSpeed.php
+++ b/lib/W3/PageSpeed.php
@@ -17,12 +17,20 @@ class W3_PageSpeed {
     var $key = '';
 
     /**
+     * Referrer for key restricting
+     *
+     * @var string
+     */
+    var $key_restrict_referrer = '';
+    
+    /**
      * PHP5-style constructor
      */
     function __construct() {
         $config = w3_instance('W3_Config');
 
         $this->key = $config->get_string('widget.pagespeed.key');
+        $this->key_restrict_referrer = $config->get_string('widget.pagespeed.key.restrict.referrer');
     }
 
     /**
@@ -71,7 +79,8 @@ class W3_PageSpeed {
             'key' => $this->key,
         ));
 
-        $response = w3_http_get($request_url);
+        $headers= array('headers'  => array("Referer" => $this->key_restrict_referrer));
+        $response = w3_http_get($request_url,$headers);
 
         if (!is_wp_error($response) && $response['response']['code'] == 200) {
             return $response['body'];
@@ -102,7 +111,7 @@ class W3_PageSpeed {
             foreach ((array) $data->formattedResults->ruleResults as $i => $rule_result) {
                 $results['rules'][$i] = array(
                     'name' => $rule_result->localizedRuleName,
-                    'score' => $rule_result->ruleScore,
+                    'score' => isset($rule_result->ruleScore)?$rule_result->ruleScore:"",
                     'impact' => $rule_result->ruleImpact,
                     'priority' => $this->_get_priority($rule_result->ruleImpact),
                     'resolution' => $this->_get_resolution($rule_result->localizedRuleName),

--- a/lib/W3/UI/Settings/General.php
+++ b/lib/W3/UI/Settings/General.php
@@ -7,6 +7,7 @@ class W3_UI_Settings_General extends W3_UI_Settings_SettingsBase{
             'general' => array(
                 'widget.pagespeed.enabled' => __('Enable Google Page Speed dashboard widget', 'w3-total-cache'),
                 'widget.pagespeed.key' => __('Page Speed <acronym title="Application Programming Interface">API</acronym> Key:', 'w3-total-cache'),
+                'widget.pagespeed.key.restrict.referrer' => __('Key Restriction (Referrer):', 'w3-total-cache'),
                 'common.force_master' => __('Use single network configuration file for all sites.', 'w3-total-cache'),
                 'common.visible_by_master_only' => __('Hide performance settings', 'w3-total-cache'),
                 'config.path' => __('Nginx server configuration file path', 'w3-total-cache'),

--- a/lib/W3/Widget/PageSpeed.php
+++ b/lib/W3/Widget/PageSpeed.php
@@ -68,6 +68,7 @@ class W3_Widget_PageSpeed extends W3_Plugin{
             w3_require_once(W3TC_LIB_W3_DIR . '/Request.php');
 
             $this->_config->set('widget.pagespeed.key', W3_Request::get_string('w3tc_widget_pagespeed_key'));
+            $this->_config->set('widget.pagespeed.key.restrict.referrer', W3_Request::get_string('widget_pagespeed_key_restrict_referrer'));
             $this->_config->save();
         }
         include W3TC_INC_DIR . '/widget/pagespeed_control.php';

--- a/lib/W3/Widget/Services.php
+++ b/lib/W3/Widget/Services.php
@@ -86,12 +86,6 @@ class W3_Widget_Services extends W3_Plugin {
      * @return void
      */
     function wp_dashboard_setup() {
-        w3tc_add_dashboard_widget('w3tc_services', __('Premium Services', 'w3-total-cache'), array(
-            &$this,
-            'widget_form'
-        ),null, 'normal',
-        'div'
-        );
     }
 
     function widget_form() {


### PR DESCRIPTION
## In This Commit:

**1. Included a feature to allow users to provide an optional http referrer (via a new input field under General Settings) which can be used as a key restriction parameter for the PageSpeed console's credentials area.  This fixes an issue some were having when using the PageSpeed widget**

![pagespeed_key_restriction_referrer](https://cloud.githubusercontent.com/assets/5191497/18574146/078f11f2-7b98-11e6-8559-4381d42873ea.jpg)

**2. Fixed an error that was triggered by a pagespeed response; due to a change in the pagespeed api, a field that was expected was no longer available.**

**3. Removed the General Setting's Licensing widget and the Dashboard's Premium Services Buy Now widget. #60**
### General Settings: Licensing

![general_settings_licensing](https://cloud.githubusercontent.com/assets/5191497/18572095/0a6394f0-7b86-11e6-9344-c5bf3392f4f0.jpg)
### Dashboard: Premium Services Buy Now

![dashboard_premium](https://cloud.githubusercontent.com/assets/5191497/18572092/0383be08-7b86-11e6-86f7-b67ec1546449.jpg)
