### PR TITLE
Smarter Browser Cache Defaults

### DIFF
--- a/configs/0.9.4.4-ConfigKeys.php
+++ b/configs/0.9.4.4-ConfigKeys.php
@@ -1184,7 +1184,7 @@ $keys = array(
     ),
     'browsercache.cssjs.expires' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.lifetime' => array(
         'type' => 'integer',
@@ -1192,11 +1192,11 @@ $keys = array(
     ),
     'browsercache.cssjs.nocookies' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.cache.control' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.cache.policy' => array(
         'type' => 'string',
@@ -1204,11 +1204,11 @@ $keys = array(
     ),
     'browsercache.cssjs.etag' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.w3tc' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.replace' => array(
         'type' => 'boolean',
@@ -1224,7 +1224,7 @@ $keys = array(
     ),
     'browsercache.html.expires' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.html.lifetime' => array(
         'type' => 'integer',
@@ -1232,7 +1232,7 @@ $keys = array(
     ),
     'browsercache.html.cache.control' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.html.cache.policy' => array(
         'type' => 'string',
@@ -1240,11 +1240,11 @@ $keys = array(
     ),
     'browsercache.html.etag' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.html.w3tc' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.html.replace' => array(
         'type' => 'boolean',
@@ -1256,11 +1256,11 @@ $keys = array(
     ),
     'browsercache.other.compression' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.other.expires' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.lifetime' => array(
         'type' => 'integer',
@@ -1268,11 +1268,11 @@ $keys = array(
     ),
     'browsercache.other.nocookies' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.cache.control' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.cache.policy' => array(
         'type' => 'string',
@@ -1280,7 +1280,7 @@ $keys = array(
     ),
     'browsercache.other.etag' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.w3tc' => array(
         'type' => 'boolean',


### PR DESCRIPTION
Every once in a while, you get a really simple question about why I get missing gzip or expires these are smarter default settings for the browser cache. 

Break Down.

CSS/JS
All settings enabled but query strings because these are use case specific and don't offer any performance benefit. All other options are enabled by default

HTML
All options should be enabled

Media & More
No GZIP Or Query Strings. 
Media files are a compressed format and gzip is intended for plain text it shouldn't be used on images its a waste of server resources. Query strings see above. 

Simple patch that puts this more in line with plugins like WP Rocket.