### PR TITLE
A tweak to the previous Minify Notification Update  #54

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -1634,3 +1634,14 @@ function w3_is_enterprise($config = null) {
 function w3tc_edge_mode() {
     return defined('W3TC_EDGE_MODE') && W3TC_EDGE_MODE;
 }
+
+/**
+ * Increments the minify version caused by a full page/minify cache flush
+ */
+function w3_minify_version_change() {
+    $config_admin = w3_instance('W3_ConfigAdmin');
+    $cur_min_ver = $config_admin->get_integer('minify.version');
+    $config_admin->set('minify.version', ++$cur_min_ver);
+    $config_admin->save();
+}
+

--- a/lib/W3/CacheFlushLocal.php
+++ b/lib/W3/CacheFlushLocal.php
@@ -87,7 +87,6 @@ class W3_CacheFlushLocal {
      */
     function pgcache_flush() {
         do_action('w3tc_pgcache_flush');
-        $this->pgcache_flush_minify_version_change();
         $pgcacheflush = w3_instance('W3_PgCacheFlush');
         return $pgcacheflush->flush();
     }
@@ -390,12 +389,5 @@ class W3_CacheFlushLocal {
         /** @var $pgcache W3_Plugin_PgCacheAdmin */
         $pgcache = w3_instance('W3_Plugin_PgCacheAdmin');
         return $pgcache->prime_post($post_id);
-    }
-    
-    function pgcache_flush_minify_version_change() {
-        $config_admin = w3_instance('W3_ConfigAdmin');
-        $cur_min_ver = $config_admin->get_integer('minify.version');
-        $config_admin->set('minify.version', ++$cur_min_ver);
-        $config_admin->save();
     }
 }

--- a/lib/W3/Minify.php
+++ b/lib/W3/Minify.php
@@ -258,7 +258,7 @@ class W3_Minify {
          * Minify!
          */
         try {
-            if (isset($_GET['f']) || isset($serve_options['minApp']['groups'][$_GET['g']]))        
+            if (isset($_GET['f']) || isset($serve_options['minApp']['groups'][$_GET['g']]))
                 Minify::serve('MinApp', $serve_options);
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
@@ -280,6 +280,7 @@ class W3_Minify {
      */
     function flush() {
         $cache = $this->_get_cache();
+        w3_minify_version_change();
 
         return $cache->flush();
     }

--- a/lib/W3/Minify.php
+++ b/lib/W3/Minify.php
@@ -258,7 +258,7 @@ class W3_Minify {
          * Minify!
          */
         try {
-            if (isset($_GET['f']) || isset($serve_options['minApp']['groups'][$_GET['g']]))
+            if (!empty($_GET['f']) || (isset($_GET['g']) && !empty($serve_options['minApp']['groups'][$_GET['g']])))
                 Minify::serve('MinApp', $serve_options);
         } catch (Exception $exception) {
             $this->error($exception->getMessage());

--- a/lib/W3/PgCacheFlush.php
+++ b/lib/W3/PgCacheFlush.php
@@ -43,6 +43,7 @@ class W3_PgCacheFlush extends W3_PgCache {
      */
     function flush() {
         $cache = $this->_get_cache();
+        w3_minify_version_change();
         return $cache->flush();
     }
 


### PR DESCRIPTION
I had forgotten to increment the minify version when the minify cache was also cleared.  I had only incremented it when the page cache was cleared.  Although in most cases it is the page cache that when cleared (say, due to a plugin removal) it should be incremented, but for cases where the user adjusts their minify settings to say smaller file length sizes, it can potentially result in different minify file names and so its best to also increment the version variable for this case too -- i forgot about that.

I also moved the minify version update function into the define.php file so the function could be accessed from one central location instead of being duplicated twice (for pg cache class and minify class).
