### PR TITLE
Smart Browser Cache Defaults (Revision)

### DIFF
--- a/configs/0.9.4.4-ConfigKeys.php
+++ b/configs/0.9.4.4-ConfigKeys.php
@@ -1184,7 +1184,7 @@ $keys = array(
     ),
     'browsercache.cssjs.expires' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.cssjs.lifetime' => array(
         'type' => 'integer',
@@ -1192,11 +1192,11 @@ $keys = array(
     ),
     'browsercache.cssjs.nocookies' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.cssjs.cache.control' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.cssjs.cache.policy' => array(
         'type' => 'string',
@@ -1204,11 +1204,11 @@ $keys = array(
     ),
     'browsercache.cssjs.etag' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.cssjs.w3tc' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.cssjs.replace' => array(
         'type' => 'boolean',
@@ -1224,7 +1224,7 @@ $keys = array(
     ),
     'browsercache.html.expires' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.html.lifetime' => array(
         'type' => 'integer',
@@ -1232,7 +1232,7 @@ $keys = array(
     ),
     'browsercache.html.cache.control' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.html.cache.policy' => array(
         'type' => 'string',
@@ -1240,11 +1240,11 @@ $keys = array(
     ),
     'browsercache.html.etag' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.html.w3tc' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.html.replace' => array(
         'type' => 'boolean',
@@ -1256,11 +1256,11 @@ $keys = array(
     ),
     'browsercache.other.compression' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.expires' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.other.lifetime' => array(
         'type' => 'integer',
@@ -1268,11 +1268,11 @@ $keys = array(
     ),
     'browsercache.other.nocookies' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.other.cache.control' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.other.cache.policy' => array(
         'type' => 'string',
@@ -1280,7 +1280,7 @@ $keys = array(
     ),
     'browsercache.other.etag' => array(
         'type' => 'boolean',
-        'default' => true
+        'default' => false
     ),
     'browsercache.other.w3tc' => array(
         'type' => 'boolean',

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -1247,7 +1247,7 @@ $keys = array(
     ),
     'browsercache.cssjs.expires' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.lifetime' => array(
         'type' => 'integer',
@@ -1255,11 +1255,11 @@ $keys = array(
     ),
     'browsercache.cssjs.nocookies' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.cache.control' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.cache.policy' => array(
         'type' => 'string',
@@ -1267,7 +1267,7 @@ $keys = array(
     ),
     'browsercache.cssjs.etag' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.cssjs.w3tc' => array(
         'type' => 'boolean',
@@ -1287,7 +1287,7 @@ $keys = array(
     ),
     'browsercache.html.expires' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.html.lifetime' => array(
         'type' => 'integer',
@@ -1295,7 +1295,7 @@ $keys = array(
     ),
     'browsercache.html.cache.control' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.html.cache.policy' => array(
         'type' => 'string',
@@ -1303,7 +1303,7 @@ $keys = array(
     ),
     'browsercache.html.etag' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.html.w3tc' => array(
         'type' => 'boolean',
@@ -1323,7 +1323,7 @@ $keys = array(
     ),
     'browsercache.other.expires' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.lifetime' => array(
         'type' => 'integer',
@@ -1331,11 +1331,11 @@ $keys = array(
     ),
     'browsercache.other.nocookies' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.cache.control' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.cache.policy' => array(
         'type' => 'string',
@@ -1343,7 +1343,7 @@ $keys = array(
     ),
     'browsercache.other.etag' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'browsercache.other.w3tc' => array(
         'type' => 'boolean',


### PR DESCRIPTION
Fixed some mistakes seen in commit #62 by @volnus

The original commit was done to the compatibility file _0.9.4.4-ConfigKeys.php_ instead of _ConfigKeys.php_.  I shifted the new defaults into ConfigKeys.php and reverted 0.9.4.4-ConfigKeys.php back to its original self.

Although most of the new defaults have been kept, there were 3 defaults that had to be changed back: 

`browsercache.cssjs.w3tc`
`browsercache.html.w3tc`
`browsercache.other.compression`

The first two were put back to **false** because these options only bloat up response data by including the unnecessary header: `X-Powered-By: W3 Total Cache`.  The last was put back to true since @volnus mistakenly thought this compresses non-text files.  When enabled this actually only compresses ico and json mimes for Apache, and the ico mime for Nginx.  Json is a text file.  And although ico is not a text file it is common practice to compress it.  So it's efficient to keep browsercache.other.compression set to true.
