### PR TITLE
Amazon Cloudfront - Expires header

### DIFF
--- a/inc/options/browsercache.php
+++ b/inc/options/browsercache.php
@@ -36,7 +36,7 @@
                     <label>
                         <input id="browsercache_expires" type="checkbox" name="expires"
                             <?php $this->sealing_disabled('browsercache') ?>
-                            value="1"<?php checked($browsercache_expires && $this->_config->get_string('cdn.engine') != 'cf2', true); ?> <?php disabled($this->_config->get_string('cdn.engine') == 'cf2' ) ?> /> <?php _e('Set expires header', 'w3-total-cache'); ?></label>
+                            value="1"<?php checked($browsercache_expires); ?> /> <?php _e('Set expires header', 'w3-total-cache'); ?></label>
                     <br /><span class="description"><?php _e('Set the expires header to encourage browser caching of files.', 'w3-total-cache'); ?></span>
                 </th>
             </tr>
@@ -133,7 +133,7 @@
             <?php endif; ?>
             <tr>
                 <th colspan="2">
-                    <?php $this->checkbox('browsercache.cssjs.expires', $this->_config->get_string('cdn.engine') == 'cf2') ?> <?php w3_e_config_label('browsercache.cssjs.expires') ?></label>
+                    <?php $this->checkbox('browsercache.cssjs.expires') ?> <?php w3_e_config_label('browsercache.cssjs.expires') ?></label>
                     <br /><span class="description"><?php _e('Set the expires header to encourage browser caching of files.', 'w3-total-cache'); ?></span>
                 </th>
             </tr>
@@ -223,7 +223,7 @@
             <?php endif; ?>
             <tr>
                 <th colspan="2">
-                    <?php $this->checkbox('browsercache.html.expires', $this->_config->get_string('cdn.engine') == 'cf2') ?> <?php w3_e_config_label('browsercache.html.expires') ?></label>
+                    <?php $this->checkbox('browsercache.html.expires') ?> <?php w3_e_config_label('browsercache.html.expires') ?></label>
                     <br /><span class="description"><?php _e('Set the expires header to encourage browser caching of files.', 'w3-total-cache'); ?></span>
                 </th>
             </tr>
@@ -299,7 +299,7 @@
             <?php endif; ?>
             <tr>
                 <th colspan="2">
-                    <?php $this->checkbox('browsercache.other.expires', $this->_config->get_string('cdn.engine') == 'cf2') ?> <?php w3_e_config_label('browsercache.other.expires') ?></label>
+                    <?php $this->checkbox('browsercache.other.expires') ?> <?php w3_e_config_label('browsercache.other.expires') ?></label>
                     <br /><span class="description"><?php _e('Set the expires header to encourage browser caching of files.', 'w3-total-cache'); ?></span>
                 </th>
             </tr>

--- a/lib/W3/AdminActions/DefaultActionsAdmin.php
+++ b/lib/W3/AdminActions/DefaultActionsAdmin.php
@@ -613,12 +613,7 @@ class W3_AdminActions_DefaultActionsAdmin {
             }
 
         }
-        //CloudFront does not support expires header. So disable it when its used
-        if ($config->get_string('cdn.engine') == 'cf2') {
-            $config->set('browsercache.cssjs.expires', false);
-            $config->set('browsercache.html.expires', false);
-            $config->set('browsercache.other.expires', false);
-        }
+
         $config = apply_filters('w3tc_save_options', $config, $this->_config, $config_admin);
         $config = apply_filters("w3tc_save_options-{$this->_page}", $config, $this->_config, $config_admin);
 


### PR DESCRIPTION
It seems w3tc intentionally does not permit the use of the Expires header when "_Amazon Cloudfront_" (origin pull) is selected as a CDN.  [This link](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#ExpirationDownloadDist) shows Amazon does support the Expires header and so this commit re-enables the ability to use Expires.

Also, a bug was found whereby despite having CDN disabled, if you select "Amazon Cloudfront" (origin pull) all Expires headers checkboxes (under Browser Cache) become disabled and unchecked.  The fix would have been to do a verify that the CDN checkbox was enabled (and Amazon Cloudfront was the type) but because the Expires header is now supported by Amazon i just ended up removing the disabling ability entirely.
