### PR TITLE
Expanded Regular Expression Support

### DIFF
--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -497,7 +497,7 @@
                 <td>
                     <textarea id="minify_reject_uri" name="minify.reject.uri" 
                         <?php $this->sealing_disabled('minify') ?> cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('minify.reject.uri'))); ?></textarea><br />
-                    <span class="description"><?php _e('Always ignore the specified pages / directories.', 'w3-total-cache'); ?></span>
+                    <span class="description"><?php _e('Always ignore the specified pages / directories. Use relative paths. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <tr>
@@ -505,7 +505,7 @@
                 <td>
                     <textarea id="minify_reject_files_js" name="minify.reject.files.js"
                         <?php $this->sealing_disabled('minify') ?> cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('minify.reject.files.js'))); ?></textarea><br />
-                    <span class="description"><?php _e('Always ignore the specified JS files.', 'w3-total-cache'); ?></span>
+                    <span class="description"><?php _e('Always ignore the specified JS files. Use relative paths. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <tr>
@@ -513,7 +513,7 @@
                 <td>
                     <textarea id="minify_reject_files_css" name="minify.reject.files.css"
                         <?php $this->sealing_disabled('minify') ?> cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('minify.reject.files.css'))); ?></textarea><br />
-                    <span class="description"><?php _e('Always ignore the specified CSS files.', 'w3-total-cache'); ?></span>
+                    <span class="description"><?php _e('Always ignore the specified CSS files. Use relative paths. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <tr>
@@ -522,7 +522,7 @@
                     <textarea id="minify_reject_ua" name="minify.reject.ua"
                         <?php $this->sealing_disabled('minify') ?>
                         cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('minify.reject.ua'))); ?></textarea><br />
-                    <span class="description"><?php _e('Specify user agents that will never receive minified content.', 'w3-total-cache'); ?></span>
+                    <span class="description"><?php _e('Specify user agents that will never receive minified content. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <?php if ($auto): ?>
@@ -532,7 +532,7 @@
                     <textarea id="minify_cache_files" name="minify.cache.files"
                         <?php $this->sealing_disabled('minify') ?>
                               cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('minify.cache.files'))); ?></textarea><br />
-                    <span class="description"><?php _e('Specify external files/libraries that should be combined.', 'w3-total-cache'); ?></span>
+                    <span class="description"><?php _e('Specify external files/libraries that should be combined. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <?php endif; ?>

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -342,7 +342,7 @@
                     <textarea id="pgcache_accept_qs" name="pgcache.accept.qs"
                         <?php $this->sealing_disabled('pgcache') ?>
                               cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('pgcache.accept.qs'))); ?></textarea><br />
-                    <span class="description"><?php _e('Always cache URLs with these query strings.', 'w3-total-cache'); ?></span>
+                    <span class="description"><?php _e('Always cache URLs with these query strings. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <tr>
@@ -360,7 +360,7 @@
                     <textarea id="pgcache_reject_cookie" name="pgcache.reject.cookie" 
                         <?php $this->sealing_disabled('pgcache') ?>
                         cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('pgcache.reject.cookie'))); ?></textarea><br />
-                    <span class="description"><?php _e('Never cache pages that use the specified cookies.', 'w3-total-cache'); ?></span>
+                    <span class="description"><?php _e('Never cache pages that use the specified cookies. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <tr>
@@ -369,12 +369,7 @@
                     <textarea id="pgcache_reject_uri" name="pgcache.reject.uri" 
                         <?php $this->sealing_disabled('pgcache') ?>
                         cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('pgcache.reject.uri'))); ?></textarea><br />
-                    <span class="description">
-						<?php 
-							echo sprintf( 
-								__( 'Always ignore the specified pages / directories. Supports regular expressions (See <a href="%s">FAQ</a>)', 'w3-total-cache'),   								network_admin_url('admin.php?page=w3tc_faq#q82')
-							); ?>
-					</span>
+                    <span class="description"><?php _e('Always ignore the specified pages / directories. Use relative paths. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <tr>
@@ -383,7 +378,7 @@
                     <textarea id="pgcache_accept_files" name="pgcache.accept.files" 
                         <?php $this->sealing_disabled('pgcache') ?>
                         cols="40" rows="5"><?php echo esc_textarea(implode("\r\n", $this->_config->get_array('pgcache.accept.files'))); ?></textarea><br />
-                    <span class="description"><?php echo sprintf( __('Cache the specified pages / directories even if listed in the "never cache the following pages" field. Supports regular expression (See <a href="%s">FAQ</a>)', 'w3-total-cache'), network_admin_url('admin.php?page=w3tc_faq#q82') ); ?></span>
+                    <span class="description"><?php _e('Cache the specified pages / directories even if listed in the "never cache the following pages" field. Use relative paths. Supports regular expressions.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <?php if (substr($permalink_structure, -1) == '/'): ?>

--- a/lib/Minify/Minify/Controller/MinApp.php
+++ b/lib/Minify/Minify/Controller/MinApp.php
@@ -72,6 +72,8 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
         } elseif (! $cOptions['groupsOnly'] && isset($_GET['f'])) {
             $config = w3_instance('W3_Config');
             $external = $config->get_array('minify.cache.files');
+            foreach ($external as &$val) $val = trim(str_replace("~","\~",$val));
+            $external = array_filter($external,function($val){return $val != "";});
 
             $files = $_GET['f'];
             $temp_files = array();
@@ -80,11 +82,7 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
                 if (!is_string($file)) {
                     $url = $file->minifyOptions['prependRelativePath'];
                     $verified  = false;
-                    foreach($external as $ext) {
-                        if(preg_match('#'.w3_get_url_regexp($ext).'#',$url) && !$verified){
-                            $verified = true;
-                        }
-                    }
+                    if (!empty($external) && @preg_match('~'.implode("|",$external).'~i',$url) && !$verified) $verified = true;
                     if (!$verified) {
                         $this->log("GET['f'] param part invalid, not in accepted external files list: \"{$url}\"");
                         return $options;

--- a/lib/W3/Minify.php
+++ b/lib/W3/Minify.php
@@ -1106,11 +1106,11 @@ class W3_Minify {
             $verified = false;
             if (w3_is_url($file)) {
                 $external = $this->_config->get_array('minify.cache.files');
-                foreach($external as $ext) {
-                    if(preg_match('#'.w3_get_url_regexp($ext).'#',$file) && !$verified){
-                        $verified = true;
-                    }
-                }
+
+                foreach ($external as &$val) $val = trim(str_replace("~","\~",$val));
+                $external = array_filter($external,function($val){return $val != "";});
+                if (!empty($external) && @preg_match('~'.implode("|",$external).'~i',$file) && !$verified) $verified = true;
+                
                 if (!$verified) {
                     $this->error(sprintf('Remote file not in external files/libraries list: "%s"', $file));
                 }

--- a/lib/W3/PgCacheAdminEnvironment.php
+++ b/lib/W3/PgCacheAdminEnvironment.php
@@ -742,7 +742,7 @@ class W3_PgCacheAdminEnvironment {
         /**
          * Check for rejected cookies
          */
-        $use_cache_rules .= "    RewriteCond %{HTTP_COOKIE} !(" . implode('|', array_map('w3_preg_quote', $reject_cookies)) . ") [NC]\n";
+        $use_cache_rules .= "    RewriteCond %{HTTP_COOKIE} !(" . implode('|', $reject_cookies) . ") [NC]\n";
 
         /**
          * Check for rejected user agents
@@ -918,7 +918,7 @@ class W3_PgCacheAdminEnvironment {
         /**
          * Check for rejected cookies
          */
-        $rules .= "if (\$http_cookie ~* \"(" . implode('|', array_map('w3_preg_quote', $reject_cookies)) . ")\") {\n";
+        $rules .= "if (\$http_cookie ~* \"(" . implode('|', $reject_cookies) . ")\") {\n";
         $rules .= "    set \$w3tc_rewrite 0;\n";
         $rules .= "}\n";
 

--- a/lib/W3/UI/MinifyAdminView.php
+++ b/lib/W3/UI/MinifyAdminView.php
@@ -629,7 +629,19 @@ class W3_UI_MinifyAdminView extends W3_UI_PluginView {
         $files = array_map('w3_normalize_file_minify', $files);
         $files = array_unique($files);
         $ignore_files = $this->_config->get_array('minify.reject.files.js');
-        $files = array_diff($files, $ignore_files);
+        
+        foreach ($ignore_files as &$val) $val = trim(str_replace("~","\~",$val));
+        $ignore_files = array_filter($ignore_files,function($val){return $val != "";});
+
+        if (!empty($ignore_files))
+        {
+        	  $diff = array();
+            foreach($files as $file)
+                if (!@preg_match('~'.implode("|",$ignore_files).'~i',$file))
+                    $diff[] = $file;
+            $files = $diff;                   
+        }
+                
         return $files;
     }
 
@@ -647,7 +659,18 @@ class W3_UI_MinifyAdminView extends W3_UI_PluginView {
         $files = array_map('w3_normalize_file_minify', $files);
         $files = array_unique($files);
         $ignore_files = $this->_config->get_array('minify.reject.files.css');
-        $files = array_diff($files, $ignore_files);
+
+        foreach ($ignore_files as &$val) $val = trim(str_replace("~","\~",$val));
+        $ignore_files = array_filter($ignore_files,function($val){return $val != "";});
+
+        if (!empty($ignore_files))
+        {
+        	  $diff = array();
+            foreach($files as $file)
+                if (!@preg_match('~'.implode("|",$ignore_files).'~i',$file))
+                    $diff[] = $file;
+            $files = $diff;                   
+        }
 
         return $files;
     }


### PR DESCRIPTION
To provide better robustness i added full regex support for the following fields:
### Page Cache

`Accepted Query Strings`
`Rejected Cookies`
`Cache Exception List`
### Minify

`Never Minify the Following Pages`
`Never Minify the Following JS Files`
`Never Minify the Following CSS Files`
`Rejected User Agents`
`Include External Files/Libraries`

I also fix issues (bugs?) in page cache's `Accept Query Strings` field and `Reject Cookies` field.  They originally only accepted keys and so if someone gave a "key=value" pair it would have failed despite the key existing.

I also fixed a bug for the `Cache Exception List`.  While analyzing the code, i noticed that there were no viable paths to get entries in this list to work.  And also, despite what this field's description claimed about superseding matched entries found in the `Never Cache the Following Pages` field, that was not the case.  It's fixed now.
