### PR TITLE
Change location of apply_filter in PgCache.php

### DIFF
--- a/lib/W3/PgCache.php
+++ b/lib/W3/PgCache.php
@@ -115,7 +115,7 @@ class W3_PgCache {
 
     var $_old_exists = false;
     /**
-     * Returns instance. 
+     * Returns instance.
      * For backward compatibility with 0.9.2.3 version of /wp-content files
      *
      * @return W3_PgCache
@@ -138,7 +138,6 @@ class W3_PgCache {
         if ($pos !== false)
             $request_host = substr($request_host, 0, $pos);
         $this->_request_host = $request_host;
-
         $this->_request_uri = $_SERVER['REQUEST_URI'];
         $this->_lifetime = $this->_config->get_integer('pgcache.lifetime');
         $this->_late_init = $this->_config->get_boolean('pgcache.late_init');
@@ -580,7 +579,7 @@ class W3_PgCache {
 
             return false;
         }
-        
+
         return true;
     }
 
@@ -769,10 +768,10 @@ class W3_PgCache {
         if (!$this->_config->get_boolean('pgcache.reject.logged_roles'))
              return true;
         $roles = $this->_config->get_array('pgcache.reject.roles');
-        
+
         if (empty($roles))
             return true;
-        
+
         foreach (array_keys($_COOKIE) as $cookie_name) {
             if (strpos($cookie_name, 'w3tc_logged_') === 0) {
                 foreach($roles as $role) {
@@ -983,7 +982,7 @@ class W3_PgCache {
      * @param string $request_uri
      * @return string
      */
-    function _get_page_key($mobile_group = '', $referrer_group = '', 
+    function _get_page_key($mobile_group = '', $referrer_group = '',
         $encryption = '', $compression = '', $content_type = '', $request_uri = '') {
 
         if ($request_uri){
@@ -1540,6 +1539,18 @@ class W3_PgCache {
         } elseif ($this->_sitemap_matched)
             $group = 'sitemaps';
 
+        /**
+	 * Filters the current theme page cache lifetime.
+	 *
+	 * @since 0.9.4.5
+	 *
+	 * @param integer $_lifetime      The page cache lifetime.
+	 * @param string  $_request_uri   The URI of the page.
+	 * @param integer $mobile_group   The request's mobile group.
+	 * @param integer $referrer_group The request's referrer group.
+	 */
+        $_expire = apply_filters('w3tc_pgcache_lifetime', $this->_lifetime, $this->_request_uri, $mobile_group, $referrer_group);
+               
         foreach ($compressions as $_compression) {
             $_page_key = $this->_get_page_key($mobile_group,
                 $referrer_group, $encryption, $_compression,
@@ -1562,7 +1573,7 @@ class W3_PgCache {
                 'content' => &$buffers[$_compression]
             );
 
-            $cache->set($_page_key, $_data, $this->_lifetime, $group);
+            $cache->set($_page_key, $_data, $_expire, $group);
         }
 
         /**


### PR DESCRIPTION
This pull request moves the location of the page cache's "expire" filter and adds a couple of extra parameters that developers can use (mobile group and referrer group).
