### PR TITLE
Sitemap's URL Entry - Default Priority Value

### DIFF
--- a/lib/W3/Plugin/PgCacheAdmin.php
+++ b/lib/W3/Plugin/PgCacheAdmin.php
@@ -175,7 +175,7 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
 
                 foreach ($url_matches[1] as $url_match) {
                     $loc = '';
-                    $priority = 0;
+                    $priority = 0.5;
 
                     if (preg_match('~<loc>(.*?)</loc>~is', $url_match, $loc_matches)) {
                         $loc = trim($loc_matches[1]);


### PR DESCRIPTION
Although plugins like Yoast have dropped the use of the `priority` attribute w3tc required that the priority existed for each url entry in a sitemap.  If such priority did not exist (despite a correlating url) it would ignore the entry entirely, and features like prime caching would no longer work for all entries that did not have a priority, which in most cases would be the entire sitemap.

By simply modifying the default priority to 0.5, which is the standard default value for this attribute, it corrects this problem and allows urls with no priority to continue to be processed.

Issue discussed here #80 
