### PR TITLE
Feeds (rss, rss2, atom, rdf) Not Caching

### DIFF
--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -437,12 +437,12 @@
                     <span class="description"><?php _e('Specify additional page headers to cache.', 'w3-total-cache')?></span>
                 </td>
             </tr>
-            <?php if (w3_is_nginx() && $this->_config->get_string('pgcache.engine') == 'file_generic'): ?>
+            <?php if ($this->_config->get_string('pgcache.engine') == 'file_generic'): ?>
             <tr>
-                <th><label><?php w3_e_config_label('pgcache.cache.nginx_handle_xml') ?></label></th>
+                <th><label><?php w3_e_config_label(w3_is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml') ?></label></th>
                 <td>
-                    <?php $this->checkbox('pgcache.cache.nginx_handle_xml', true) ?> <?php w3_e_config_label('pgcache.cache.nginx_handle_xml') ?></label><br />
-                    <span class="description"><?php _e('Return correct Content-Type header for XML files. Slows down cache engine.', 'w3-total-cache'); ?></span>
+                    <?php $this->checkbox(w3_is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml', w3_is_nginx()?true:false) ?> <?php w3_e_config_label(w3_is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml') ?></label><br />
+                    <span class="description"><?php _e('Return correct Content-Type header for XML files (e.g., feeds and sitemaps). Slows down cache engine.', 'w3-total-cache'); ?></span>
                 </td>
             </tr>
             <?php endif; ?>

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -489,7 +489,7 @@ $keys = array(
     ),
     'pgcache.purge.sitemap_regex' => array(
         'type' => 'string',
-        'default' => '([a-z0-9_\-]*?)sitemap([a-z0-9_\-]*)?\.xml'
+        'default' => '[a-z0-9_\-]*sitemap[a-z0-9_\-]*\.(xml|xsl|html?)(\.gz)?'
     ),
     'pgcache.prime.enabled' => array(
         'type' => 'boolean',

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -319,6 +319,10 @@ $keys = array(
         'type' => 'boolean',
         'default' => false
     ),
+    'pgcache.cache.apache_handle_xml' => array(
+        'type' => 'boolean',
+        'default' => true
+    ),
     'pgcache.cache.ssl' => array(
         'type' => 'boolean',
         'default' => false
@@ -350,11 +354,7 @@ $keys = array(
     ),
     'pgcache.accept.uri' => array(
         'type' => 'array',
-        'default' => array(
-            'sitemap(_index)?\.xml(\.gz)?',
-            '([a-z0-9_\-]+)?sitemap\.xsl',
-            '[a-z0-9_\-]+-sitemap([0-9]+)?\.xml(\.gz)?'
-        )
+        'default' => array()
     ),
     'pgcache.accept.files' => array(
         'type' => 'array',
@@ -388,7 +388,8 @@ $keys = array(
         'type' => 'array',
         'default' => array(
             'wp-.*\.php',
-            'index\.php'
+            'index\.php',
+            '[a-z0-9_\-]*sitemap[a-z0-9_\-]*\.(xml|xsl|html?)(\.gz)?'
         )
     ),
     'pgcache.reject.categories' => array(

--- a/lib/W3/PgCache.php
+++ b/lib/W3/PgCache.php
@@ -1574,7 +1574,7 @@ class W3_PgCache {
         }
 
         $cache_headers = apply_filters('w3tc_is_cacheable_content_type',
-            array('application/json', 'text/html', 'text/xml', 'application/xhtml+xml'));
+            array('application/json', 'text/html', 'text/xml', 'application/xhtml+xml', 'application/rss+xml', 'application/atom+xml', 'application/rdf+xml'));
         return in_array($content_type, $cache_headers);
     }
 

--- a/lib/W3/PgCache.php
+++ b/lib/W3/PgCache.php
@@ -1167,11 +1167,20 @@ class W3_PgCache {
              * Append HTML extension.
              * For nginx - we create .xml cache entries and redirect to them
              */
-            if (w3_is_nginx() && substr($content_type, 0, 8) == 'text/xml' &&
-                  $this->_config->get_boolean('pgcache.cache.nginx_handle_xml'))
-                $key .= '.xml';
-            else
-                $key .= '.html';
+
+             $ext = "html";
+             if (@preg_match("~(text/xml|application/rdf\+xml|application/rss\+xml|application/atom\+xml)~i",$content_type) || strpos($request_uri,"/feed/") !==false) $ext = "xml";
+
+		   if (w3_is_nginx())
+		   {
+		   	if (!$this->_config->get_boolean('pgcache.cache.nginx_handle_xml')) $ext = "html";
+		   }
+		   else
+		   {
+		   	if (!$this->_config->get_boolean('pgcache.cache.apache_handle_xml')) $ext = "html";
+		   }
+            
+             $key .= ".$ext";
         }
 
         /**
@@ -1628,8 +1637,9 @@ class W3_PgCache {
 
         if ($this->_enhanced_mode && !$this->_late_init) {
             $this->_check_rules_present();
-            if (isset($headers['Content-Type']))
-                $content_type = $headers['Content-Type'];
+            foreach( $headers as $key => $value )
+		      if(strtolower( $key ) == 'content-type')
+		      	$content_type = $value;
         }
 
         $time = time();

--- a/lib/W3/PgCacheAdminEnvironment.php
+++ b/lib/W3/PgCacheAdminEnvironment.php
@@ -777,6 +777,14 @@ class W3_PgCacheAdminEnvironment {
         $rules .= "    RewriteRule .* \"" . $uri_prefix . $ext .
             $env_W3TC_ENC . "\" [L]\n";
 
+        if ($config->get_boolean('pgcache.cache.apache_handle_xml')) {
+            $ext = '.xml';
+            $rules .= "    RewriteCond \"" . $document_root . $uri_prefix . $ext .
+                $env_W3TC_ENC . "\"" . $switch . "\n";
+            $rules .= "    RewriteRule .* \"" . $uri_prefix . $ext .
+                $env_W3TC_ENC . "\" [L]\n";
+        }
+
         $rules .= "</IfModule>\n";
 
         $rules .= W3TC_MARKER_END_PGCACHE_CORE . "\n";

--- a/lib/W3/Plugin/Minify.php
+++ b/lib/W3/Plugin/Minify.php
@@ -167,8 +167,8 @@ class W3_Plugin_Minify extends W3_Plugin {
 
                             $buffer = str_replace('<!-- W3TC-include-css -->', '', $buffer);
                             if ($embed_pos === false) {
-                                preg_match('~<head(\s+[^<>]+)*>~Ui', $buffer, $match, PREG_OFFSET_CAPTURE);
-                                $embed_pos = strlen($match[0][0]) + $match[0][1];
+                                if (preg_match('~<head(\s+[^<>]+)*>~Ui', $buffer, $match, PREG_OFFSET_CAPTURE))
+                                    $embed_pos = strlen($match[0][0]) + $match[0][1];
                             }
 
                             //$ignore_css_files = array_map('w3_normalize_file', $ignore_css_files);

--- a/lib/W3/UI/Settings/PageCache.php
+++ b/lib/W3/UI/Settings/PageCache.php
@@ -62,6 +62,7 @@ class W3_UI_Settings_PageCache extends W3_UI_Settings_SettingsBase{
                 'pgcache.accept.uri' =>  __('Non-trailing slash pages:', 'w3-total-cache'),
                 'pgcache.cache.headers' =>  __('Specify page headers:', 'w3-total-cache'),
                 'pgcache.cache.nginx_handle_xml' => __('Handle <acronym title="Extensible Markup Language">XML</acronym> mime type', 'w3-total-cache'),
+                'pgcache.cache.apache_handle_xml' => __('Handle <acronym title="Extensible Markup Language">XML</acronym> mime type', 'w3-total-cache'),
     )
         );
     }


### PR DESCRIPTION
When using the `Cache Feeds` checkbox under Page Cache it is suppose to cache feeds as identified by wp's _is_feed()_ function.  However, w3tc assumed the content type of feeds was just _text/xml_ (which was true in older wp versions) but current wp iterations now set the feed content types to _application/rss+xml_, _application/atom+xml_, etc.  As such, prior to this fix w3tc did not cache any feeds (that i know of).

Also a minor tweak was made to the `Purge Sitemaps` default regex.
## Update

Ok i've just done a new commit that now allows feeds and sitemaps to return back their correct content-type (xml) when using Disk: Enhanced.  

I've done some thorough tests and it seems to work really well.  I can cache feeds (rss, rss2, atom, rdf) and retrieve them from cache properly.  Because caching feeds finally are working i recommend people use the "_Purge Policy_" checkboxes to manage when these cached feeds get cleared (e.g., when its associating post is updated or a new comment is made).

I verified that minify for sitemaps and feeds work very well.  I tested these minified files against W3C Feed Verification service and they passed.

I also fixed a [php warning notice](https://github.com/szepeviktor/fix-w3tc/pull/85/files#diff-9751a09488be6cf7208ade6039decb96R170) in Minify.php that occured when attempting to minify an xml file.  It was looking for a _<head>_ tag when none exists for xml files.

I added a new option `Handle XML mime type` under _Advanced_ of Page Cache which is checked on by default that, as the name suggests, is for handling the feeds/sitemap content-type issue.  I figured maybe someone might want the ability to toggle this and make it revert back to w3tc's old way (all returned content is treated as if it were html).

By default, I placed a sitemap regex entry into the _Never Cache the Following Pages_ by default.  I did this as a precaution in case, on first install, someone doesn't want their sitemaps to be cached.  So it is up to them to remove this regex entry for sitemaps to begin caching.
