### PR TITLE
Modified Readme.md and Updated WP's Plugin Page Display Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A community driven build of W3 Total Cache, originally developed by [@ftownes](h
 _**Note:** This list does not reflect all of the myriad of fixes/changes -- just the key ones of interest_
 
 ![check] Removed Deprecated WordPress Code<br>
-![check] Full PHP7 Compliant (Passes [PHPCompatibility](https://github.com/wimg/PHPCompatibility): 100%)<br>
+![check] Full PHP7 Compliancy (Passes [PHPCompatibility](https://github.com/wimg/PHPCompatibility): 100%)<br>
 ![check] Memcache & Memcached Extension Support<br>
 ![check] APCu Support<br>
 ![check] OPcache Support<br>

--- a/README.md
+++ b/README.md
@@ -1,93 +1,29 @@
 # Fix W3TC (W3 Total Cache) [![Build Status](https://travis-ci.org/szepeviktor/fix-w3tc.svg?branch=master)](https://travis-ci.org/szepeviktor/fix-w3tc)
 
-Fix and customize W3 Total Cache by [@ftownes](https://github.com/ftownes)
+A community driven build of W3 Total Cache, originally developed by [@ftownes](https://github.com/ftownes).  The aim is to continuously incorporate fixes, improvements, and enhancements over the official (and long abandoned: 2 years) Wordpress release of [W3 Total Cache v0.9.4.1](https://wordpress.org/plugins/w3-total-cache/).
+
+[check]: http://www.ingenuity.com/wp-content/uploads/2013/06/checkmark-survey-icon.png "Logo Title Text 1"
+[uncheck]: http://iconshow.me/media/images/ui/ios7-icons/png/16/circle-outline.png "Off Title Text 1"
 
 ### Installation
 
-1. Deactivate official plugin from WP.org
-1. Delete plugin directory `w3-total-cache` by hand, DO NOT click "Delete" on Plugins page
-1. Unpack [master](https://github.com/szepeviktor/fix-w3tc/archive/master.zip) in `/wp-content/plugins/`
+1. Deactivate your existing W3 Total Cache plugin (if it exists).  **_DO NOT_ CLICK THE "DELETE" BUTTON!**
+1. Use FTP or some other file manager to navigate to `/wp-content/plugins/` and delete your existing `w3-total-cache` plugin directory.
+1. Download and unpack: **_[Master](https://github.com/szepeviktor/fix-w3tc/archive/master.zip)_** into `/wp-content/plugins/`
 1. Rename the extracted directory from `fix-w3tc-master` to `w3-total-cache`
-1. Activate w3tc
-1. Check that it's working
+1. Activate the W3 Total Cache plugin
 
-### Fix
+### Fixes, Improvements, & Enhancement Highlights
+_**Note:** This list does not reflect all of the myriad of fixes/changes -- just the key ones of interest_
 
-- [x] Modernize deprecated WordPress code
-- [x] Support PHP7 [disallow reference arguments](https://github.com/php/php-src/commit/fafe01b)
-- [x] Add Memcache(d) support
-- [x] Add APCu support
-- [x] Support OPcache
-- [x] Support WOFF2 font format
-- [x] Fix https caching
-- [ ] [Halfdone CloudFlare support in trunk](https://github.com/szepeviktor/fix-w3tc/issues/68)
-- [x] Support AMP
-- [x] Support Redis
-
-### And customize
-
-- [x] Disable edge mode `evaluation.reminder`
-- [x] Hide most widgets from W3TC Dashboard
-- [x] Remove informational submenus `$pages_tail`
-- [x] Remove contextual help `w3tc_*`
-- [x] Make admin pages smaller `#w3tc h2.logo { float: right; }`
-- [x] Remove HTML comment by hooking `w3tc_can_print_comment`
-- [x] Disable EDD/licensing
-
-### Disabled submenus
-
-- FAQ
-- Support
-- Install
-- About
-
-### Disabled W3TC plugins
-
-- W3_Plugin_NewRelicAdmin
-- W3_Licensing
-
-### Disabled W3TC widgets
-
-- W3_Widget_SpreadTheWord
-- W3_Widget_News
-- W3_Widget_Forum
-- W3_Widget_MaxCDN
-- W3_Widget_NetDNA
-- W3_Widget_NewRelic
-
-### Mini CI
-
-```bash
-find -type f -name "*.php" -exec php -l "{}" ";"
-```
-
-### Upstream
-
-svn: https://plugins.svn.wordpress.org/w3-total-cache/
-
-git: https://github.com/wp-plugins/w3-total-cache.git
-
-### PHP 7 support
-
-In version 7.0.9 reference arguments were disallowed in `call_user_func()`.
-
-This is how to find them in the code:
-
-```bash
-grep -Fnr 'ob_callback(&$buffer)' w3-total-cache/*
-```
-
-Props. [IT Nota](https://www.itnota.com/fixing-php7-compatibility-issue-w3-total-cache/)
-
-### Alternatives
-
-- https://github.com/bermanco/w3-total-cache-php7
-- https://github.com/tperalta82/w3-total-cache-ng
-- https://github.com/wp-plugins/w3tc-auto-pilot
-- https://github.com/StefanoWP/W3-Total-Cache-WordPress-Plugin-Default-Settings
-
-<!--
-configwriter: master.phps ???
-inspect alternative
-try Google Page Speed API on dashboard widget
--->
+![check] Removed Deprecated WordPress Code<br>
+![check] Full PHP7 Compliant (Passes [PHPCompatibility](https://github.com/wimg/PHPCompatibility): 100%)<br>
+![check] Memcache & Memcached Extension Support<br>
+![check] APCu Support<br>
+![check] OPcache Support<br>
+![check] WOFF2 Font Support<br>
+![check] Proper HTTPS Caching<br>
+![check] AMP Support<br>
+![check] Redis Support<br>
+![check] Removed Nag Screens, Obsolete Widgets, & Licensing<br>
+![uncheck] Improved CloudFlare Support (**_Status_**: [Half-done](https://github.com/szepeviktor/fix-w3tc/issues/68))

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A community driven build of W3 Total Cache, originally developed by [@ftownes](https://github.com/ftownes).  The aim is to continuously incorporate fixes, improvements, and enhancements over the official (and long abandoned: 2 years) Wordpress release of [W3 Total Cache v0.9.4.1](https://wordpress.org/plugins/w3-total-cache/).
 
-[check]: http://www.ingenuity.com/wp-content/uploads/2013/06/checkmark-survey-icon.png "Logo Title Text 1"
-[uncheck]: http://iconshow.me/media/images/ui/ios7-icons/png/16/circle-outline.png "Off Title Text 1"
+[DONE]: http://i65.tinypic.com/2dbjpn6.png "Feature Integrated"
+[PENDING]: http://i68.tinypic.com/25000tw.png "Still Pending"
 
 ### Installation
 
@@ -16,14 +16,14 @@ A community driven build of W3 Total Cache, originally developed by [@ftownes](h
 ### Fixes, Improvements, & Enhancement Highlights
 _**Note:** This list does not reflect all of the myriad of fixes/changes -- just the key ones of interest_
 
-![check] Removed Deprecated WordPress Code<br>
-![check] Full PHP7 Compliancy (Passes [PHPCompatibility](https://github.com/wimg/PHPCompatibility): 100%)<br>
-![check] Memcache & Memcached Extension Support<br>
-![check] APCu Support<br>
-![check] OPcache Support<br>
-![check] WOFF2 Font Support<br>
-![check] Proper HTTPS Caching<br>
-![check] AMP Support<br>
-![check] Redis Support<br>
-![check] Removed Nag Screens, Obsolete Widgets, & Licensing<br>
-![uncheck] Improved CloudFlare Support (**_Status_**: [Half-done](https://github.com/szepeviktor/fix-w3tc/issues/68))
+![DONE] Removed Deprecated WordPress Code<br>
+![DONE] Full PHP7 Compliancy (Passes [PHPCompatibility](https://github.com/wimg/PHPCompatibility): 100%)<br>
+![DONE] Memcache & Memcached Extension Support<br>
+![DONE] APCu Support<br>
+![DONE] OPcache Support<br>
+![DONE] WOFF2 Font Support<br>
+![DONE] Proper HTTPS Caching<br>
+![DONE] AMP Support<br>
+![DONE] Redis Support<br>
+![DONE] Removed Nag Screens, Obsolete Widgets, & Licensing<br>
+![PENDING] Improved CloudFlare Support (**_Status_**: [Half-done](https://github.com/szepeviktor/fix-w3tc/issues/68))

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: W3 Total Cache
+Plugin Name: W3 Total Cache (Fixed)
 Description: The highest rated and most complete WordPress performance plugin. Dramatically improve the speed and user experience of your site. Add browser, page, object and database caching as well as minify and content delivery network (CDN) to WordPress.
 Version: 0.9.4.5
 Plugin URI: http://www.w3-edge.com/wordpress-plugins/w3-total-cache/


### PR DESCRIPTION
Not sure if this is too extreme but i modified the README.md file to be more concise with what people will want to know and less heavy on the technical speak.  If it's too extreme then feel free to drop this PR.

Also, within WP's Plugin screen fix-w3tc currently displays as "_W3 Total Cache_".  I figured maybe appending "(Fixed)" to its display name would be in order so it now shows as "_W3 Total Cache (Fixed)_" under the Plugins page.
