### PR TITLE
Option to Hide Update notification & Fragment Caching ParseError exception handling (PHP7)

### DIFF
--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -577,6 +577,10 @@
         <table class="form-table">
             <tr>
                 <th colspan="2">
+                </th>
+            </tr>
+            <tr>
+                <th colspan="2">
                     <input type="hidden" name="widget.pagespeed.enabled" value="0" />
                     <label><input type="checkbox" name="widget.pagespeed.enabled" value="1"<?php checked($this->_config->get_boolean('widget.pagespeed.enabled'), true); ?> />  <?php w3_e_config_label('widget.pagespeed.enabled', 'general') ?></label>
                     <br /><span class="description"><?php _e('Display Google Page Speed results on the WordPress dashboard.', 'w3-total-cache'); ?></span>

--- a/lib/W3/PgCache.php
+++ b/lib/W3/PgCache.php
@@ -1508,7 +1508,16 @@ class W3_PgCache {
             $code = trim($code, ';') . ';';
 
             ob_start();
-            $result = eval($code);
+            try {
+                $result = eval($code);
+            
+                if (defined('PHP_MAJOR_VERSION') && PHP_MAJOR_VERSION >= 7) {            
+            	    $result = true;
+                }
+            } catch (ParseError $e) {
+                $result = false;
+            }
+            
             $output = ob_get_contents();
             ob_end_clean();
 

--- a/lib/W3/Root.php
+++ b/lib/W3/Root.php
@@ -75,6 +75,10 @@ class W3_Root {
             &$this,
             'deactivate'
         ));
+
+        if ($this->_config->get_boolean('config.w3tc.update') ) {
+	       add_filter( 'site_transient_update_plugins', 'w3tc_remove_update_notification' );
+	   }
     }
 
     /**

--- a/lib/W3/UI/Settings/General.php
+++ b/lib/W3/UI/Settings/General.php
@@ -12,7 +12,7 @@ class W3_UI_Settings_General extends W3_UI_Settings_SettingsBase{
                 'common.visible_by_master_only' => __('Hide performance settings', 'w3-total-cache'),
                 'config.path' => __('Nginx server configuration file path', 'w3-total-cache'),
                 'config.check' => __('Verify rewrite rules', 'w3-total-cache'),
-                'plugin.license_key' => __('License', 'w3-total-cache')
+                'plugin.license_key' => __('License', 'w3-total-cache'),
             )
         );
     }


### PR DESCRIPTION
1. Adds a new "_Hide Plugin Update Notification_" checkbox under General Settings' Miscellaneous area. This allows the user to decide if they want to hide the WordPress notification message about updating to the latest w3tc.
2. This resolves a minor issue when users implement _<--mfunc_ but trigger a _ParseError_ exception when using php7.  Prior to php7 the _eval()_ function returned false when an error occurred.  w3tc would then display a friendly error message on screen and resume.  As of php7 the code is halted on parse errors.  This revision makes it so that when using php7 a parsing error will act like previous php versions when using w3tc by informing the user but continuing to process the page.
