### PR TITLE
Hide Update notification & Added Fragment Caching Exception Handling

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -1645,3 +1645,10 @@ function w3_minify_version_change() {
     $config_admin->save();
 }
 
+/**
+ * Prevents w3tc from popping up notification messages about needing to be updated
+ */
+function w3tc_remove_update_notification( $value ) {
+     unset($value->response[ 'w3-total-cache/w3-total-cache.php' ]);
+     return $value;
+}

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -577,6 +577,13 @@
         <table class="form-table">
             <tr>
                 <th colspan="2">
+                    <input type="hidden" name="config.w3tc.update" value="0" />
+                    <label><input type="checkbox" name="config.w3tc.update" value="1"<?php checked($this->_config->get_boolean('config.w3tc.update'), true); ?> /> <?php w3_e_config_label('config.w3tc.update', 'general') ?></label>
+                    <br /><span class="description"><?php _e('Hide the WordPress notification message about updating W3 Total Cache.', 'w3-total-cache'); ?></span>
+                </th>
+            </tr>
+            <tr>
+                <th colspan="2">
                     <input type="hidden" name="widget.pagespeed.enabled" value="0" />
                     <label><input type="checkbox" name="widget.pagespeed.enabled" value="1"<?php checked($this->_config->get_boolean('widget.pagespeed.enabled'), true); ?> />  <?php w3_e_config_label('widget.pagespeed.enabled', 'general') ?></label>
                     <br /><span class="description"><?php _e('Display Google Page Speed results on the WordPress dashboard.', 'w3-total-cache'); ?></span>

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -1603,6 +1603,10 @@ $keys = array(
         'type' => 'string',
         'default' => ''
     ),
+    'config.w3tc.update' => array(
+        'type' => 'boolean',
+        'default' => false
+    ),
     'widget.latest.items' => array(
         'type' => 'integer',
         'default' => 3

--- a/lib/W3/PgCache.php
+++ b/lib/W3/PgCache.php
@@ -1508,7 +1508,16 @@ class W3_PgCache {
             $code = trim($code, ';') . ';';
 
             ob_start();
-            $result = eval($code);
+            try {
+                $result = eval($code);
+            
+                if (defined('PHP_MAJOR_VERSION') && PHP_MAJOR_VERSION >= 7) {            
+            	    $result = true;
+                }
+            } catch (ParseError $e) {
+                $result = false;
+            }
+            
             $output = ob_get_contents();
             ob_end_clean();
 

--- a/lib/W3/Root.php
+++ b/lib/W3/Root.php
@@ -75,6 +75,10 @@ class W3_Root {
             &$this,
             'deactivate'
         ));
+
+        if ($this->_config->get_boolean('config.w3tc.update') ) {
+	       add_filter( 'site_transient_update_plugins', 'w3tc_remove_update_notification' );
+	   }
     }
 
     /**

--- a/lib/W3/UI/Settings/General.php
+++ b/lib/W3/UI/Settings/General.php
@@ -12,7 +12,8 @@ class W3_UI_Settings_General extends W3_UI_Settings_SettingsBase{
                 'common.visible_by_master_only' => __('Hide performance settings', 'w3-total-cache'),
                 'config.path' => __('Nginx server configuration file path', 'w3-total-cache'),
                 'config.check' => __('Verify rewrite rules', 'w3-total-cache'),
-                'plugin.license_key' => __('License', 'w3-total-cache')
+                'plugin.license_key' => __('License', 'w3-total-cache'),
+                'config.w3tc.update' => __('Hide Plugin Update Notification', 'w3-total-cache')
             )
         );
     }


### PR DESCRIPTION
1. Added a new _Hide Plugin Update Notification_ checkbox under General Settings' Miscellaneous area. This allows the user to decide if they want to hide the WordPress notification message about updating to the
   latest w3tc.
2. This resolves a minor issue when users implement **<--mfunc** but trigger a _ParseError_ exception when using php7. Prior to php7 the _eval()_ function returned false when an error occurred. w3tc would then display a friendly error message on screen and resume. As of php7 the code is halted on parse errors. This revision makes it so that when using php7 a parsing error will act like previous php versions when using w3tc by informing the user but continuing to process the page.
