### PR TITLE
Fix Prevent Updating

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -1649,6 +1649,8 @@ function w3_minify_version_change() {
  * Prevents w3tc from popping up notification messages about needing to be updated
  */
 function w3tc_remove_update_notification( $value ) {
-     unset($value->response[ 'w3-total-cache/w3-total-cache.php' ]);
+     if( $value ) {
+         unset($value->response[ 'w3-total-cache/w3-total-cache.php' ]);
+     }
      return $value;
 }


### PR DESCRIPTION
If you don't use the if conditional before unset it will cause a PHP warning.

> PHP Warning: Attempt to modify property of non-object in /public_html/wp-content/plugins/w3-total-cache/inc/define.php on line 1652
