### PR TITLE
Fix undefined variable $debug

### DIFF
--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -549,6 +549,8 @@ class Minify_MinifiedFileRequestHandler {
 
 		$message = '<h1>W3TC Minify Error</h1>';
 
+		$debug = false;
+		
 		if ( $debug ) {
 			$message .= sprintf( '<p>%s.</p>', $error );
 		} else {


### PR DESCRIPTION
from https://wordpress.org/support/topic/undefined-variable-debug/

> PHP Notice: Undefined variable: debug in Minify_MinifiedFileRequestHandler.php on line 552
