### PR TITLE
Fix fatal error: Call to undefined method flush_pgcache()

### DIFF
--- a/Generic_AdminActions_Flush.php
+++ b/Generic_AdminActions_Flush.php
@@ -247,7 +247,7 @@ class Generic_AdminActions_Flush {
 			$state_note->set( 'common.show_note.flush_posts_needed', false );
 			$state_note->set( 'common.show_note.plugins_updated', false );
 
-			$this->flush_pgcache();
+			$this->w3tc_flush_pgcache();
 		}
 
 		if ( $this->_config->get_string( 'dbcache.engine' ) == $type && $this->_config->get_boolean( 'dbcache.enabled' ) ) {


### PR DESCRIPTION
from https://wordpress.org/support/topic/w3-total-cache-errors-and-not-flush-page-cache/

> Fatal error: Call to undefined method W3TC\Generic_AdminActions_Flush::flush_pgcache() in /public_html/wp-content/plugins/w3-total-cache/Generic_AdminActions_Flush.php on line 250
