### PR TITLE
Silence 'failed to open stream warning'

### DIFF
--- a/lib/W3/ObjectCacheAdminEnvironment.php
+++ b/lib/W3/ObjectCacheAdminEnvironment.php
@@ -124,7 +124,7 @@ class W3_ObjectCacheAdminEnvironment {
      * @throws FilesystemOperationException
      */
     private function delete_addin() {
-        if ($this->is_objectcache_add_in())
+        if (file_exists(W3TC_ADDIN_FILE_OBJECT_CACHE) && $this->is_objectcache_add_in())
             w3_wp_delete_file(W3TC_ADDIN_FILE_OBJECT_CACHE);
     }
 


### PR DESCRIPTION
The routine does not check to see if object-cache.php exists before attempting to delete it. Check first to avoid the following warning:

file_get_contents(/home/xxxxxxxx/public_html/wp-content/object-cache.php): failed to open stream: No such file or directory
