### PR TITLE
Update Rollup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,40 +2,63 @@
 * Removed Deprecated WordPress Code
 * WP-CLI new feature: Prime cache pages
 * Support for WEBP image format
-* Enabled Hide Update notification by default
-* Allow embedding of minified JS and CSS content directly into the HTML page (good for AMP, Service Workers, and prefetching)
-* Fixed several security issues
-* Fragment caching fix when using PHP7
-* Proper caching and client-side returns of feeds and sitemaps for disk enhanced when "Handle XML Mime Type" is selected.
-* Yoast sitemap fix
-* Flush cached sitemaps
-* New fields under Page Cache Adcanced section: Never cache pages associated with categories, tags, authors, and custom fields
+* New feature to allow embedding of minified JS and CSS content directly into the HTML page (good for AMP, Service Workers, and prefetching)
 * Fixed bug where it was attempting to delete an addin object cache file before knowing if it existed
-* Added "w3tc_pgcache_lifetime" filter to allow control of how long a page can live
+
+= 0.9.4.5.5 =
+* Adds a new "Hide Plugin Update Notification" checkbox under General Settings' Miscellaneous area
+* Fragment caching fix when using PHP7
+* Modified the support link that is visible in the Admin bar to point ot this fork's Issues forum
+* Addendum to make ready for WP 4.7+ changes that was made back in 0.9.4.5.1
+* Fix to the Hide Update Notification message that was causing problems when deactivating/adding plugins
+
+= 0.9.4.5.4 =
+* Fixes the 4 security flaws (security token bypass, file upload/download, eval)
+
+= 0.9.4.5.3 =
+* Fixed sitemap plugins like Yoast which dropped the priority attribute
+* No longer includes external scripts and styles for AMP pages (see v0.4.5.6 for a new feature that allows minified files to be embeded)
+* Proper caching and client-side returns of feeds and sitemaps for disk enhanced when "Handle XML Mime Type" is selected
+* Fixed a PHP warning notice that occurred when attempting to minify an xml file
+* Tweak was made to the Purge Sitemaps default regex
+* Sitemaps are now set to not cach by default on fresh installs
+* Modified wp's plugin page display name to reflect the real name of this repo
+* Page cache bug fix -- Was allowing the calling script to auto allow itself to be cached as well as allowing queries to be cached
+
+= 0.9.4.5.2 =
+* Adjusted "w3tc_pgcache_lifetime" filter and added extra optional parameters
+* New fields under Page Cache Advanced section: Never cache pages associated with categories, tags, authors, and custom fields
+* Flush cached sitemaps
+* Cleaned up dashboard
+* Fixed security issue -- xss vulnerability
+
+= 0.9.4.5.1 =
 * Expanded regular expression support for several Page Cache and Minify fields
-* Fixed a bug for the "Cache Exception List" field.
-* Amazon Cloudfront (origin pull) expires header now works
-* Fixed a bug where all "Expires Header" checkboxes became unchecked and disabled whern just selecting Amazon Cloudfront (origin pull) despite the CDN not being enabled
-* Added smart browser cache default settings
 * Google PageSpeed - added a new feature (under General Settings) to allow users to provide an optional http referrer for better security
-* nginx rules fix.
+* Amazon Cloudfront (origin pull) expires header now works
+* w3tc_pgcache_lifetime filter
+* nginx rules fix
+* Alow the use of "~" (tilde) in boxes that allow for regex input
+* Added "w3tc_pgcache_lifetime" filter to allow control of how long a page can live
+* Added smart browser cache default settings
+* WP v4.7+ changes the behavior of $wp_filter so this has now been reflected in code
+* Fixed a bug for the "Cache Exception List" field.
+* Fixed a bug where all "Expires Header" checkboxes became unchecked and disabled when just selecting Amazon Cloudfront (origin pull) despite the CDN not being enabled
 * Fixes the "Recently an error occurred while creating the CSS / JS minify cache: File "XXX" doesn't exist" bug
 * URL parsing fix for page cache flushing
 * SSL caching -- fixes a bug where SSL pages were always getting cached despite the "Cache SSL (https) Requests" option being unchecked
 * Fixes the role removal issue bug
-* memcached library support
+* Memcached Extension Support
+* Fixed incorrect labels on Redis settings page
 * Page cache compatibility mode now Apache 2.4+ aware
 * Load balancer fix -- for ssl sites behind load balancers
 * Fixes an old locale bug
-* WP v4.7+ changes the behavior of $wp_filter so this has now been reflected in code
 * "Accepted Query Strings" field and "Rejected Cookies" field allow for key/value pairs input as well as regex support
-* Alow the use of "~" (tilde) in boxes that allow for regex input
 
 = 0.9.4.5 =
-* Checkbox to "Hide Update Notifications" 
 * Removed Deprecated WordPress Code
 * Full PHP7 Compliancy (Passes PHPCompatibility: 100%)
-* Memcache & Memcached Extension Support
+* Memcache Extension Support
 * APCu Support
 * OPcache Support
 * WOFF2 Font Support

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,38 @@
+= 0.9.4.5.6 =
+* Removed Deprecated WordPress Code
+* WP-CLI new feature: Prime cache pages
+* Support for WEBP image format
+* Enabled Hide Update notification by default
+* Allow embedding of minified JS and CSS content directly into the HTML page (good for AMP, Service Workers, and prefetching)
+* Fixed several security issues
+* Fragment caching fix when using PHP7
+* Proper caching and client-side returns of feeds and sitemaps for disk enhanced when "Handle XML Mime Type" is selected.
+* Yoast sitemap fix
+* Flush cached sitemaps
+* New fields under Page Cache Adcanced section: Never cache pages associated with categories, tags, authors, and custom fields
+* Fixed bug where it was attempting to delete an addin object cache file before knowing if it existed
+* Added "w3tc_pgcache_lifetime" filter to allow control of how long a page can live
+* Expanded regular expression support for several Page Cache and Minify fields
+* Fixed a bug for the "Cache Exception List" field.
+* Amazon Cloudfront (origin pull) expires header now works
+* Fixed a bug where all "Expires Header" checkboxes became unchecked and disabled whern just selecting Amazon Cloudfront (origin pull) despite the CDN not being enabled
+* Added smart browser cache default settings
+* Google PageSpeed - added a new feature (under General Settings) to allow users to provide an optional http referrer for better security
+* nginx rules fix.
+* Fixes the "Recently an error occurred while creating the CSS / JS minify cache: File "XXX" doesn't exist" bug
+* URL parsing fix for page cache flushing
+* SSL caching -- fixes a bug where SSL pages were always getting cached despite the "Cache SSL (https) Requests" option being unchecked
+* Fixes the role removal issue bug
+* memcached library support
+* Page cache compatibility mode now Apache 2.4+ aware
+* Load balancer fix -- for ssl sites behind load balancers
+* Fixes an old locale bug
+* WP v4.7+ changes the behavior of $wp_filter so this has now been reflected in code
+* "Accepted Query Strings" field and "Rejected Cookies" field allow for key/value pairs input as well as regex support
+* Alow the use of "~" (tilde) in boxes that allow for regex input
+
 = 0.9.4.5 =
+* Checkbox to "Hide Update Notifications" 
 * Removed Deprecated WordPress Code
 * Full PHP7 Compliancy (Passes PHPCompatibility: 100%)
 * Memcache & Memcached Extension Support

--- a/inc/define.php
+++ b/inc/define.php
@@ -21,6 +21,7 @@ define('W3TC_SUPPORT_REQUEST_URL', 'https://www.w3-edge.com/w3tc/support/');
 define('W3TC_TRACK_URL', 'https://www.w3-edge.com/w3tc/track/');
 define('W3TC_MAILLINGLIST_SIGNUP_URL', 'https://www.w3-edge.com/w3tc/emailsignup/');
 define('W3TC_MINIFY_VER_ID', '#MVER#');
+define("W3TC_CLI_FILE",".w3tc_cli");
 define('NEWRELIC_SIGNUP_URL', 'http://bit.ly/w3tc-partner-newrelic-signup');
 define('MAXCDN_SIGNUP_URL', 'http://bit.ly/w3tc-cdn-maxcdn-create-account');
 define('MAXCDN_AUTHORIZE_URL', 'http://bit.ly/w3tc-cdn-maxcdn-authorize');
@@ -1649,8 +1650,80 @@ function w3_minify_version_change() {
  * Prevents w3tc from popping up notification messages about needing to be updated
  */
 function w3tc_remove_update_notification( $value ) {
-     if( $value ) {
-         unset($value->response[ 'w3-total-cache/w3-total-cache.php' ]);
+    if( $value ) {
+        unset($value->response[ 'w3-total-cache/w3-total-cache.php' ]);
      }
      return $value;
+}
+
+function w3_lock_read($file)
+{
+    $res = false;
+    $h = @fopen($file,'r');
+
+    if ($h !== false)
+    {
+        flock($h,LOCK_SH);
+
+        clearstatcache(true,$file);
+        $sz = filesize($file);
+
+        if ($sz > 0)
+            $res = fread($h,$sz);
+        else
+            $res = "";
+
+        flock($h,LOCK_UN);
+        fclose($h);
+
+        $res = unserialize($res);
+    }
+
+    return $res;
+}
+
+function w3_lock_write($file,$data)
+{
+    $res = false;
+    $h = @fopen($file,'c');
+
+    if ($h !== false)
+    {
+        flock($h,LOCK_EX);
+
+        ftruncate($h,0);
+        $res = fwrite($h,serialize($data));
+        fflush($h);
+        flock($h,LOCK_UN);
+        fclose($h);
+    }
+
+    return $res;
+}
+
+function w3_clear_hook_crons($hook) 
+{
+    $res = false;    
+    $crons = _get_cron_array();
+    if ( empty( $crons ) ) {
+        return false;
+    }
+    foreach( $crons as $timestamp => $cron ) {
+        if ( ! empty( $cron[$hook] ) )  {
+            unset( $crons[$timestamp][$hook] );
+            $res = true;
+        }
+
+        if ( empty( $crons[$timestamp] ) ) {
+            unset( $crons[$timestamp] );
+        }
+    }
+    _set_cron_array( $crons );
+    return $res;
+}
+
+function w3_cmd_enabled($cmd)
+{
+  $disabled = explode(',', ini_get('disable_functions'));
+  return !in_array($cmd, $disabled);
 }

--- a/inc/define.php
+++ b/inc/define.php
@@ -21,6 +21,7 @@ define('W3TC_SUPPORT_REQUEST_URL', 'https://www.w3-edge.com/w3tc/support/');
 define('W3TC_TRACK_URL', 'https://www.w3-edge.com/w3tc/track/');
 define('W3TC_MAILLINGLIST_SIGNUP_URL', 'https://www.w3-edge.com/w3tc/emailsignup/');
 define('W3TC_MINIFY_VER_ID', '#MVER#');
+define("W3TC_CLI_FILE", ".w3tc_cli");
 define('NEWRELIC_SIGNUP_URL', 'http://bit.ly/w3tc-partner-newrelic-signup');
 define('MAXCDN_SIGNUP_URL', 'http://bit.ly/w3tc-cdn-maxcdn-create-account');
 define('MAXCDN_AUTHORIZE_URL', 'http://bit.ly/w3tc-cdn-maxcdn-authorize');
@@ -63,7 +64,6 @@ define('W3TC_CACHE_CONFIG_DIR', W3TC_CACHE_DIR  . '/config');
 define('W3TC_CACHE_MINIFY_DIR', W3TC_CACHE_DIR  . '/minify');
 define('W3TC_CACHE_PAGE_ENHANCED_DIR', W3TC_CACHE_DIR  . '/page_enhanced');
 define('W3TC_CACHE_TMP_DIR', W3TC_CACHE_DIR . '/tmp');
-define("W3TC_CLI_FILE", W3TC_CACHE_TMP_DIR."/.w3tc_cli");
 define('W3TC_CACHE_BLOGMAP_FILENAME', W3TC_CACHE_DIR . '/blogs.php');
 
 defined('WP_CONTENT_DIR') || define('WP_CONTENT_DIR', realpath(W3TC_DIR . '/../..'));

--- a/inc/define.php
+++ b/inc/define.php
@@ -21,7 +21,6 @@ define('W3TC_SUPPORT_REQUEST_URL', 'https://www.w3-edge.com/w3tc/support/');
 define('W3TC_TRACK_URL', 'https://www.w3-edge.com/w3tc/track/');
 define('W3TC_MAILLINGLIST_SIGNUP_URL', 'https://www.w3-edge.com/w3tc/emailsignup/');
 define('W3TC_MINIFY_VER_ID', '#MVER#');
-define("W3TC_CLI_FILE",".w3tc_cli");
 define('NEWRELIC_SIGNUP_URL', 'http://bit.ly/w3tc-partner-newrelic-signup');
 define('MAXCDN_SIGNUP_URL', 'http://bit.ly/w3tc-cdn-maxcdn-create-account');
 define('MAXCDN_AUTHORIZE_URL', 'http://bit.ly/w3tc-cdn-maxcdn-authorize');
@@ -64,6 +63,7 @@ define('W3TC_CACHE_CONFIG_DIR', W3TC_CACHE_DIR  . '/config');
 define('W3TC_CACHE_MINIFY_DIR', W3TC_CACHE_DIR  . '/minify');
 define('W3TC_CACHE_PAGE_ENHANCED_DIR', W3TC_CACHE_DIR  . '/page_enhanced');
 define('W3TC_CACHE_TMP_DIR', W3TC_CACHE_DIR . '/tmp');
+define("W3TC_CLI_FILE", W3TC_CACHE_TMP_DIR."/.w3tc_cli");
 define('W3TC_CACHE_BLOGMAP_FILENAME', W3TC_CACHE_DIR . '/blogs.php');
 
 defined('WP_CONTENT_DIR') || define('WP_CONTENT_DIR', realpath(W3TC_DIR . '/../..'));

--- a/inc/functions/admin.php
+++ b/inc/functions/admin.php
@@ -298,6 +298,7 @@ function w3_config_save($current_config, $new_config, $new_config_admin) {
                 'minify.css.combine',
                 'minify.css.strip.comments',
                 'minify.css.strip.crlf',
+                'minify.css.embed_content',
                 'minify.css.imports',
                 'minify.css.groups',
                 'minify.yuicss.path.java',

--- a/inc/mime/other.php
+++ b/inc/mime/other.php
@@ -47,6 +47,7 @@ return array(
     'wri' => 'application/vnd.ms-write',
     'woff' => 'application/font-woff',
     'woff2' => 'application/font-woff2',
+    'webp' => 'image/wepb',
     'xla|xls|xlsx|xlt|xlw' => 'application/vnd.ms-excel', 
     'zip' => 'application/zip'
 );

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -157,6 +157,7 @@
             								<option value="extsrc" <?php selected('extsrc' ,$this->_config->get_string('minify.js.header.embed_type')) ?>><?php _e('Non-blocking using "extsrc"', 'w3-total-cache'); ?></option>
                                         <option value="asyncsrc" <?php selected('asyncsrc' ,$this->_config->get_string('minify.js.header.embed_type')) ?>><?php _e('Non-blocking using "asyncsrc"', 'w3-total-cache'); ?></option>
                                         <?php endif; ?>
+                                        <option value="inline" <?php selected('inline' ,$this->_config->get_string('minify.js.header.embed_type')) ?>><?php _e('Embed Content', 'w3-total-cache'); ?></option>
                                     </select>
                                 </td>
                             <?php if (!$auto): ?>
@@ -173,6 +174,7 @@
                                         <option value="nb-defer" <?php selected('nb-defer' ,$this->_config->get_string('minify.js.body.embed_type')) ?>><?php _e('Non-blocking using "defer"', 'w3-total-cache'); ?></option>
                                         <option value="extsrc" <?php selected('extsrc' ,$this->_config->get_string('minify.js.body.embed_type')) ?>><?php _e('Non-blocking using "extsrc"', 'w3-total-cache'); ?></option>
                                         <option value="asyncsrc" <?php selected('asyncsrc' ,$this->_config->get_string('minify.js.body.embed_type')) ?>><?php _e('Non-blocking using "asyncsrc"', 'w3-total-cache'); ?></option>
+                                        <option value="inline" <?php selected('inline' ,$this->_config->get_string('minify.js.body.embed_type')) ?>><?php _e('Inline Content', 'w3-total-cache'); ?></option>
                                     </select>
                                 </td>
                             </tr>
@@ -189,6 +191,7 @@
                                         <option value="nb-defer" <?php selected('nb-defer' ,$this->_config->get_string('minify.js.footer.embed_type')) ?>><?php _e('Non-blocking using "defer"', 'w3-total-cache'); ?></option>
                                         <option value="extsrc" <?php selected('extsrc' ,$this->_config->get_string('minify.js.footer.embed_type')) ?>><?php _e('Non-blocking using "extsrc"', 'w3-total-cache'); ?></option>
                                         <option value="asyncsrc" <?php selected('asyncsrc' ,$this->_config->get_string('minify.js.footer.embed_type')) ?>><?php _e('Non-blocking using "asyncsrc"', 'w3-total-cache'); ?></option>
+                                        <option value="inline" <?php selected('inline' ,$this->_config->get_string('minify.js.footer.embed_type')) ?>><?php _e('Inline Content', 'w3-total-cache'); ?></option>
                                     </select>
                                 </td>
                             </tr>
@@ -324,6 +327,7 @@
                             include $css_engine_file;
                         }
                     ?>
+                    <?php $this->checkbox('minify.css.embed_content', false, 'css_') ?> <?php w3_e_config_label('minify.css.embed_content') ?></label><br />
                 </td>
             </tr>
             <tr>

--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -636,6 +636,10 @@ $keys = array(
         'type' => 'boolean',
         'default' => false
     ),
+    'minify.css.embed_content' => array(
+        'type' => 'boolean',
+        'default' => false
+    ),
     'minify.css.imports' => array(
         'type' => 'string',
         'default' => ''
@@ -867,7 +871,7 @@ $keys = array(
     ),
     'cdn.theme.files' => array(
         'type' => 'string',
-        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff;*.woff2;*.less'
+        'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.webp;*.woff;*.woff2;*.less'
     ),
     'cdn.minify.enable' => array(
         'type' => 'boolean',
@@ -1605,7 +1609,7 @@ $keys = array(
     ),
     'config.w3tc.update' => array(
         'type' => 'boolean',
-        'default' => false
+        'default' => true
     ),
     'widget.latest.items' => array(
         'type' => 'integer',

--- a/lib/W3/Minify.php
+++ b/lib/W3/Minify.php
@@ -877,6 +877,7 @@ class W3_Minify {
                                                     'minify.css.combine',
                                                     'minify.css.strip.comments',
                                                     'minify.css.strip.crlf',
+                                                    'minify.css.embed_content',
                                                     'minify.css.imports',
                                                ));
                     break;

--- a/lib/W3/PgCacheAdminEnvironment.php
+++ b/lib/W3/PgCacheAdminEnvironment.php
@@ -292,26 +292,8 @@ class W3_PgCacheAdminEnvironment {
     }
 
     private function unschedule_prime() {
-
-        // Because prime can potentially contains arguments due to "pages per interval"
-        // the standard wp_next_scheduled() check will fail when you don't provide the exact
-        // args that was used to schedule the event originally. So the following manually
-        // hunts down the prime hook and remove it
-        
-        $crons = _get_cron_array();
-        if ( empty( $crons ) ) {
-            return;
-        }
-        foreach( $crons as $timestamp => $cron ) {
-            if ( ! empty( $cron['w3_pgcache_prime'] ) )  {
-                unset( $crons[$timestamp]['w3_pgcache_prime'] );
-            }
-
-            if ( empty( $crons[$timestamp] ) ) {
-                unset( $crons[$timestamp] );
-            }
-        }
-        _set_cron_array( $crons );
+        if (wp_next_scheduled('w3_pgcache_prime'))
+            wp_clear_scheduled_hook('w3_pgcache_prime');
     }
 
 

--- a/lib/W3/Plugin/PgCache.php
+++ b/lib/W3/Plugin/PgCache.php
@@ -33,6 +33,11 @@ class W3_Plugin_PgCache extends W3_Plugin {
         add_action('w3_pgcache_prime', array(
             &$this,
             'prime'
+        ));
+
+        add_action('w3_pgcache_prime_cli', array(
+            &$this,
+            'prime_cli'
         ),10,4);
 
         add_action('publish_phone', array(
@@ -174,8 +179,18 @@ class W3_Plugin_PgCache extends W3_Plugin {
      * @param integer $start
      * @return void
      */
-    function prime($start = 0,$user_interval=-1,$user_limit=-1,$user_sitemap="") {
-        $this->_get_admin()->prime($start,$user_interval,$user_limit,$user_sitemap);
+    function prime($start = 0) {
+        $this->_get_admin()->prime($start);
+    }
+
+    /**
+     * Prime cache (WP_CLI)
+     *
+     * @param integer $start
+     * @return void
+     */
+    function prime_cli($start = 0,$user_interval=-1,$user_limit=-1,$user_sitemap="",$boot=false) {
+        $this->_get_admin()->prime_cli($start,$user_interval,$user_limit,$user_sitemap,$boot);
     }
 
     /**

--- a/lib/W3/Plugin/PgCacheAdmin.php
+++ b/lib/W3/Plugin/PgCacheAdmin.php
@@ -285,7 +285,7 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
      */    
     function get_cli_file()
     {
-        return w3_lock_read(W3TC_CLI_FILE);
+        return w3_lock_read($this->get_cli_name());
     }
 
     /**
@@ -296,7 +296,7 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
      */    
     function set_cli_file($data)
     {
-        w3_lock_write(W3TC_CLI_FILE,$data);
+        w3_lock_write($this->get_cli_name(),$data);
     }
 
     /**
@@ -306,7 +306,27 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
      */    
     function delete_cli_file()
     {
-        @unlink(W3TC_CLI_FILE);
+        @unlink($this->get_cli_name());
+    }
+    
+    /**
+     * Gets the temporary CLI file name to use
+     *     
+     * @return string - full file path
+     */
+    function get_cli_name($dir=W3TC_CACHE_TMP_DIR,$file=W3TC_CLI_FILE)
+    {
+        if (!is_dir($dir) || !is_writable($dir)) {
+            w3_mkdir_from($dir,W3TC_CACHE_DIR);
+            
+            if (!is_dir(W3TC_CACHE_TMP_DIR) || !is_writable(W3TC_CACHE_TMP_DIR)) {
+                $dir="";
+            }
+            
+            $dir = rtrim($dir,"/");
+        }
+        
+        return $dir . (empty($dir)?"":"/") . $file;
     }
     
     /**

--- a/lib/W3/Plugin/PgCacheAdmin.php
+++ b/lib/W3/Plugin/PgCacheAdmin.php
@@ -85,7 +85,7 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
      * @param integer $start
      * @return void
      */
-    function prime($start = 0,$user_interval=-1,$user_limit=-1,$user_sitemap="") {
+    function prime($start = 0) {
         $start = (int) $start;
 
         /**
@@ -98,24 +98,23 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
                 foreach ($hooks as $hook => $keys) {
                     foreach ($keys as $key => $data) {
                         if ($hook == 'w3_pgcache_prime' && count($data['args'])) {
-                            return false;
+                            return;
                         }
                     }
                 }
             }
         }
-	
-        $interval = $user_interval==-1?$this->_config->get_integer('pgcache.prime.interval'):$user_interval;
-        $limit = $user_limit==-1?$this->_config->get_integer('pgcache.prime.limit'):$user_limit;
-        $sitemap = empty($user_sitemap)?$this->_config->get_string('pgcache.prime.sitemap'):$user_sitemap;
+
+        if (!$config->get_boolean('pgcache.prime.enabled')) return;
         
+        $interval = $this->_config->get_integer('pgcache.prime.interval');
+        $limit = $this->_config->get_integer('pgcache.prime.limit');
+        $sitemap = $this->_config->get_string('pgcache.prime.sitemap');
+
         /**
          * Parse XML sitemap
          */
         $urls = $this->parse_sitemap($sitemap);
-        if (count($urls) == 0) {
-        	return "";
-        }
 
         /**
          * Queue URLs
@@ -124,10 +123,7 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
 
         if (count($urls) > ($start + $limit)) {
             wp_schedule_single_event(time() + $interval, 'w3_pgcache_prime', array(
-                $start + $limit,
-                $user_interval,
-                $user_limit,
-                $user_sitemap
+                $start + $limit
             ));
         }
 
@@ -139,13 +135,180 @@ class W3_Plugin_PgCacheAdmin extends W3_Plugin {
 
         // use empty user-agent since by default we use W3TC-powered by
         // which blocks caching
-        foreach ($queue as $url) {
+        foreach ($queue as $url)
             w3_http_get($url, array('user-agent' => ''));
-        }
-            
-        return "($limit pages every $interval secs - sitemap: $sitemap)";
     }
 
+    /**
+     * Prime cache (WP-CLI)
+     *
+     */
+    function prime_cli($start=0,$user_interval=-1,$user_limit=-1,$user_sitemap="",$boot=false) {
+
+        $interval = $user_interval==-1?$this->_config->get_integer('pgcache.prime.interval'):$user_interval;
+        $limit = $user_limit==-1?$this->_config->get_integer('pgcache.prime.limit'):$user_limit;
+        $sitemap = empty($user_sitemap)?$this->_config->get_string('pgcache.prime.sitemap'):$user_sitemap;
+
+        if ($boot)
+        {
+            /**
+             * Don't start cache prime if queues are still scheduled
+             */
+
+            if ((extension_loaded('sysvmsg') && msg_stat_queue(msg_get_queue(99909))['msg_qnum'] > 0) || 
+               $this->get_cli_file()!==false) {
+                return false;
+            }
+            
+            /**
+             * Parse XML sitemap
+             */
+            if (count($this->parse_sitemap($sitemap)) == 0) {
+                return "";
+            }            
+
+            $crons = _get_cron_array();
+
+            foreach ($crons as $timestamp => $hooks) {
+                foreach ($hooks as $hook => $keys) {
+                    foreach ($keys as $key => $data) {
+                        if ($hook == 'w3_pgcache_prime_cli' && count($data['args'])) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            
+            wp_schedule_single_event(time(), 'w3_pgcache_prime_cli', array(
+                            $start,
+                            $interval,
+                            $limit,
+                            $sitemap
+            ));
+
+            return "($limit pages every $interval secs - sitemap: $sitemap)";
+        }
+        else
+        {
+            $urls = $this->parse_sitemap($sitemap);
+            
+            /**
+             * Queue URLs
+             */
+            $queue = array_slice($urls, $start, $limit);
+
+            if (count($queue) > 0)
+            {
+                $usefile=true;
+                $msgidmain = null;
+                $msgidproc = null;
+
+                if (extension_loaded('sysvmsg'))
+                {
+                    $usefile = false;
+                    $msgidmain = msg_get_queue(99909);
+                    $msgidproc = msg_get_queue(99910);
+
+                    msg_send($msgidproc,99,"prime_proc");
+                }
+            
+                /**
+                 * Make HTTP requests and prime cache
+                 */
+                w3_require_once(W3TC_INC_DIR . '/functions/http.php');
+                w3_require_once(W3TC_INC_DIR . '/functions/url.php');
+
+                if ($usefile)
+                {
+                    $pid = getmypid();
+
+                    if (($pids=$this->get_cli_file()) === false)
+                        $pids = array();
+
+                    $pids[] = $pid;
+                    $this->set_cli_file($pids);
+                }
+                
+                if (count($urls) > ($start + $limit)) {
+                    wp_schedule_single_event(time() + $interval, 'w3_pgcache_prime_cli', array(
+                        $start + $limit,
+                        $interval,
+                        $limit,
+                        $sitemap
+                    ));
+                }
+                else
+                    $done = true;
+
+                // use empty user-agent since by default we use W3TC-powered by
+                // which blocks caching
+                foreach ($queue as $url)
+                {
+                    w3_http_get($url, array('user-agent' => ''));
+                    if ($msgidmain != null && msg_stat_queue($msgidmain)['msg_qnum'] == 0) break;
+                }
+
+                if ($usefile)
+                {
+                    if (($pids=$this->get_cli_file()) !== false)
+                    {
+                        unset($pids[array_search($pid,$pids)]);
+                        $this->set_cli_file($pids);
+                    }
+
+                    if (isset($done) && ($pids===false || count($pids) == 0))
+                    {
+                        $this->delete_cli_file();
+                        exit("Page cache priming via WP-CLI has successfully completed.\n");
+                    }
+                }
+                else
+                {
+                    msg_receive($msgidproc,99,$t,1024,$data,true,MSG_IPC_NOWAIT);
+
+                    if (msg_stat_queue($msgidproc)['msg_qnum'] == 0) {
+                        msg_remove_queue($msgidproc);
+
+                        if (msg_stat_queue($msgidmain)['msg_qnum'] == 0) {
+                            msg_remove_queue($msgidmain);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    /**
+     * Gets the active process ids handling WP-CLI prime caching
+     *     
+     * @return array
+     */    
+    function get_cli_file()
+    {
+        return w3_lock_read(W3TC_CLI_FILE);
+    }
+
+    /**
+     * Adds (or Removes) a process id handling WP-CLI prime caching
+     *
+     * @param array 
+     * @return void
+     */    
+    function set_cli_file($data)
+    {
+        w3_lock_write(W3TC_CLI_FILE,$data);
+    }
+
+    /**
+     * Deletes the WP-CLI prime caching support file
+     *     
+     * @return void
+     */    
+    function delete_cli_file()
+    {
+        @unlink(W3TC_CLI_FILE);
+    }
+    
     /**
      * Parses sitemap
      *

--- a/lib/W3/SharedRules.php
+++ b/lib/W3/SharedRules.php
@@ -88,7 +88,7 @@ class W3_SharedRules
                     return $r;
                 else
                     return 
-                        "<FilesMatch \"\.(ttf|ttc|otf|eot|woff2?|font.css)$\">\n" .
+                        "<FilesMatch \"\.(ttf|ttc|otf|eot|woff2?|webp|font.css)$\">\n" .
                         $r .
                         "</FilesMatch>\n";
 
@@ -99,7 +99,7 @@ class W3_SharedRules
                     return $r;
                 else
                     return
-                        "location ~ \\.(ttf|ttc|otf|eot|woff2?|font.css)$ {\n" .
+                        "location ~ \\.(ttf|ttc|otf|eot|woff2?|webp|font.css)$ {\n" .
                         $r .
                         "}\n";
             }

--- a/lib/W3/UI/Settings/Minify.php
+++ b/lib/W3/UI/Settings/Minify.php
@@ -53,6 +53,7 @@ class W3_UI_Settings_Minify extends W3_UI_Settings_SettingsBase{
 // options->minify->css
                 'minify.css.strip.comments' => __('Preserved comment removal (not applied when combine only is active)', 'w3-total-cache'),
                 'minify.css.strip.crlf' => __('Line break removal (not applied when combine only is active)', 'w3-total-cache'),
+                'minify.css.embed_content' => __('Embed content instead of using external file(s)', 'w3-total-cache'),
 // options->minify->csstidy
                 'minify.csstidy.options.remove_bslash' => __('Remove unnecessary backslashes', 'w3-total-cache'),
                 'minify.csstidy.options.compress_colors' => __('Compress colors', 'w3-total-cache'),

--- a/w3-total-cache.php
+++ b/w3-total-cache.php
@@ -1,11 +1,11 @@
 <?php
 /*
 Plugin Name: W3 Total Cache (Fixed)
-Description: The highest rated and most complete WordPress performance plugin. Dramatically improve the speed and user experience of your site. Add browser, page, object and database caching as well as minify and content delivery network (CDN) to WordPress.
-Version: 0.9.4.5
-Plugin URI: http://www.w3-edge.com/wordpress-plugins/w3-total-cache/
-Author: Frederick Townes
-Author URI: http://www.linkedin.com/in/w3edge
+Description: A community driven build of W3 Total Cache originally developed by @ftownes. The aim is to continuously incorporate fixes, improvements, and enhancements over the official Wordpress release of W3 Total Cache.
+Version: 0.9.4.5.6
+Plugin URI: https://github.com/szepeviktor/fix-w3tc/
+Author: Fix-W3TC Community
+Author URI: https://github.com/szepeviktor/fix-w3tc/
 Network: True
 */
 


### PR DESCRIPTION
* Removed Deprecated WordPress Code
* Added improvements to the new [WP-CLI](http://wp-cli.org/) feature -- Prime Cached Pages:
  **wp** w3-total-cache prime [**_stop_**] [**--batch**=<_size_>] [**--interval**=<_seconds_>] [**--sitemap**=<_url_>]

* Support for WEBP image format
* New feature to allow embedding of minified JS and CSS content directly into the HTML page (good for AMP, Service Workers, and prefetching).  Under _Minify > JS > Embed Type_ you will see a new drop-down item called `Embed Content` and under _Minify > CSS_ you will see a new checkbox item called `Embed Content`.
* Fixed bug where it was attempting to delete an add-in object cache file before knowing if it existed
