### PR TITLE
Default Adjustment

### DIFF
--- a/lib/W3/ConfigKeys.php
+++ b/lib/W3/ConfigKeys.php
@@ -838,7 +838,7 @@ $keys = array(
     ),
     'minify.cache.files' => array(
         'type' => 'array',
-        'default' => array('https://ajax.googleapis.com')
+        'default' => array()
     ),
 
     'cdn.enabled' => array(


### PR DESCRIPTION
Because of the previous security patch this field is being adjusted in accordance; requiring the user to more accurately specify (with regex, if necessary) what they are including externally.  The original default was too ambiguous