### PR TITLE
RackSpace Bug Fix

### DIFF
--- a/Cdn_Core.php
+++ b/Cdn_Core.php
@@ -506,7 +506,10 @@ class Cdn_Core {
 					)
 
 				);
+				$obj = new CdnEngine_Mirror_RackSpaceCdn($engine_config);
+				$obj->_on_new_access_requested_api();
 				break;
+
 			case 'rscf':
 				$state = Dispatcher::config_state();
 
@@ -526,6 +529,8 @@ class Cdn_Core {
 					)
 
 				);
+				$obj = new CdnEngine_RackSpaceCloudFiles($engine_config);
+				$obj->_on_new_access_requested_api_files();
 				break;
 
 			case 's3':


### PR DESCRIPTION
Fixes a long standing RackSpace bug only found within the v0.9.5.x releases (v0.9.4.x is unaffected).

When using RackSpace (Cloud Files and CDN) authentication gets lost and never recovered after a period of time.  All pending transmissions would be halted permanently.  The user's only course of action afterward would require him/her to login to admin and manually re-authenticate the connection via _Performance > CDN > Reauthorize_.

This occurred because W3TC stores the token (using its state class) into the db and only (potentially) updates this token after making a successful connection and performing some remote API action (e.g., upload, download).  But if this token expires prior to a connection being made then you will no longer have access to performing any more API actions.  In short, W3TC is unaware that tokens expire.

A rough analogy would be like having a hotel room key card that requires visiting the front desk every 24 hours for an update to continue to have access to your room.  In this example, W3TC would use the key card to successfully enter their hotel room, and then make a call from within their room (and only from their room) to the front desk to ask to update their key card -- which for this example, let's say the front desk allows one to do.  But what if W3TC leaves their room long enough and returns only to find their room door is locked?  Well, instead of going to the front desk W3TC panics, fails, and cries just outside their room forever.  The fix modifies this by having W3TC go to the front desk to ask to update their key before attempting to enter their room.

An alternative fix to this would have been to check for an `Unauthorized` error response.  And if found then perform a new authentication request, and then repeat the API action that had failed.  If it fails again then report the error to the user.  The problem with this approach is that an authentication failure _will_ occur in time and so a 2nd request attempt (for authentication) will have to be made to get an update.  So, if we know its going to always fail after a period of time then it seems inefficient to do it this way.

The best approach i think would be to do a modification to my official fix but store the `expires` attribute into the db and then within _get_cdn()_ (for RackSpace requests) check the token expiry and if it is within 1 hour of expiring (since RackSpace token keys expire after 24 hours of being requested) then perform a new authentication check which would then update the token that is stored in the db via the state class.  It's a very simple revision to my original fix.  I did not go with this revised approach since my current fix already resolved the problem -- lost connectivity --  and i didn't have time to identify other cases of if/when the authentication could fail prior to its expiration time; so by just doing an authentication check each time (and hence, receiving a new token which pushes its expiration time farther out in the process) it ensures authentication is always kept -- problem solved. ;P