### PR TITLE
Fix Uninitialized string offset

### DIFF
--- a/lib/Minify/Minify/CSS/UriRewriter.php
+++ b/lib/Minify/Minify/CSS/UriRewriter.php
@@ -209,7 +209,7 @@ class Minify_CSS_UriRewriter {
      */
     private static function rewriteRelative($uri, $realCurrentDir, $realDocRoot, $symlinks = array())
     {
-        if ('/' === $uri[0]) { // root-relative
+        if ( isset($uri[0]) && '/' === $uri[0]) { // root-relative
             return $uri;
         }
 


### PR DESCRIPTION
from https://wordpress.org/support/topic/uninitialized-string-offset-cssurirewriter-php/

> PHP Notice: Uninitialized string offset: 0 in /wp-content/plugins/w3-total-cache/lib/Minify/Minify/CSS/UriRewriter.php on line 379