### PR TITLE
Inconsistently nested content broke HTML inserted CSS/JS on first-run.

### DIFF
--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -105,12 +105,12 @@ class Dispatcher {
 			$data = $minify->process( $short_filename, true );
 
 			if ( !file_exists( $filename ) &&
-				isset( $data['content']['content'] ) ) {
+				isset( $data['content'] ) ) {
 
 				if ( !file_exists( dirname( $filename ) ) )
 					Util_File::mkdir_from( dirname( $filename ), W3TC_CACHE_DIR );
 			}
-			@file_put_contents( $filename, $data['content']['content'] );
+			@file_put_contents( $filename, $data['content'] );
 		}
 	}
 

--- a/Minify_MinifiedFileRequestHandler.php
+++ b/Minify_MinifiedFileRequestHandler.php
@@ -558,7 +558,7 @@ class Minify_MinifiedFileRequestHandler {
 
 		if ( $quiet ) {
 			return array(
-				'content' => array( 'content' => $message )
+				'content' => $message 
 			);
 		}
 

--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -1117,8 +1117,8 @@ class _W3_MinifyHelpers {
 		$minify = Dispatcher::component( 'Minify_MinifiedFileRequestHandler' );
 
 		$m = $minify->process( $minify_filename, true );
-		if ( isset( $m['content']['content'] ) )
-			$style = $m['content']['content'];
+		if ( isset( $m['content'] ) )
+			$style = $m['content'];
 		else
 			$style = '';
 

--- a/lib/Minify/Minify.php
+++ b/lib/Minify/Minify.php
@@ -374,12 +374,12 @@ class Minify0_Minify {
                 echo $content['content'];
             }
         } else {
+            if ($cacheIsReady)
+                $content = self::$_cache->fetch($fullCacheId);
             return array(
                 'success' => true
                 ,'statusCode' => 200
-                ,'content' => $cacheIsReady
-                    ? self::$_cache->fetch($fullCacheId)
-                    : $content['content']
+                ,'content' => $content['content']
                 ,'headers' => $headers
             );
         }


### PR DESCRIPTION
There was a really baffling bug in that, on initial generation, Minify returned a payload response with the minified code contained in `$return['content']` however on subsequent calls (when pulling from `Memcache`, for instance) the minified code was contained in `$return['content']['content']`.

At first blush, this looks accidental, however, it was referenced this way in (only) a few places, but more often than I would expect a bug to be referenced...  :-/

Ultimately, this was all kinds of broke...

Reproduce by turning on Page and JS/CSS caching, and then activate `Eliminate render-blocking CSS by moving it to HTML body`.  The very first page to get cached will have broken CSS.  Clear the Page cache, and refresh the page, and you will get the correct CSS (this is true of any page that results in a unique combination of CSS).

5 hours later... sheesh...