### PR TITLE
Remove rtf/rtx and svg/svgz from the HTML mime types

### DIFF
--- a/inc/mime/html.php
+++ b/inc/mime/html.php
@@ -5,8 +5,6 @@
  */
 return array(
     'html|htm' => 'text/html', 
-    'rtf|rtx' => 'text/richtext', 
-    'svg|svgz' => 'image/svg+xml', 
     'txt' => 'text/plain', 
     'xsd' => 'text/xsd', 
     'xsl' => 'text/xsl', 


### PR DESCRIPTION
Remove rtf/rtx and svg/svgz from the HTML mime types

Fix for https://github.com/szepeviktor/w3-total-cache-fixed/issues/242