### PR TITLE
Function isset() is faster

### DIFF
--- a/lib/W3/ConfigBase.php
+++ b/lib/W3/ConfigBase.php
@@ -90,7 +90,7 @@ class W3_ConfigBase {
      * @return mixed
      */
     function get($key, $default = null) {
-        if (array_key_exists($key, $this->_data)) {
+        if (isset($this->_data[$key])) {
             $v = $this->_data[$key];
             return $v;
         }


### PR DESCRIPTION
Function `isset()` is faster but is not the same of `array_key_exists()`.

The main difference when working on arrays is that `array_key_exists` returns `true` when the value is `null`, while isset will return `false` when the array value is set to `null`.

This is a good performance improvements and is safe only if w3tc don't use `null` how value for settings.

@amiga-500 This require a triple check before merge.