### PR TITLE
minor inline minify tweak

### DIFF
--- a/lib/Minify/HTTP/Encoder.php
+++ b/lib/Minify/HTTP/Encoder.php
@@ -282,6 +282,10 @@ class HTTP_Encoder {
      */
     protected static function _isBuggyIe()
     {
+        if(empty($_SERVER['HTTP_USER_AGENT'])) {
+            return false;
+        }
+    	
         $ua = $_SERVER['HTTP_USER_AGENT'];
         // quick escape for non-IEs
         if (0 !== strpos($ua, 'Mozilla/4.0 (compatible; MSIE ')

--- a/lib/Minify/Minify/Inline.php
+++ b/lib/Minify/Minify/Inline.php
@@ -20,7 +20,7 @@ abstract class Minify_Inline {
     }
 
     public function doMinify($content) {
-        $search = '/(<' . $this->_tag . '\\b[^>|]*?>)([\\s\\S]*?)(<\\/' . $this->_tag . '>)/i';
+        $search = '/((?:[^\'"\\/]|^)<' . $this->_tag . '\\b[^>|]*?>)([\\s\\S]*?)(<\\/' . $this->_tag . '>(?:[^\'"\\/]|$))/i';
 
         $content = preg_replace_callback($search, array($this, '_callback'), $content);
 


### PR DESCRIPTION
a few tweaks in here:
- just a small tweak when minifying inlined content

- check if the optional http_user_agent is available so it doesnt trigger the "_Undefined index: HTTP_USER_AGENT_".  I noticed this when an internal request for a minified file was made without a user agent.