### PR TITLE
omit the closing PHP tag

### DIFF
--- a/lib/W3/Db.php
+++ b/lib/W3/Db.php
@@ -493,4 +493,3 @@ class W3_DbCallUnderlying {
     }
 }
 }
-?>


### PR DESCRIPTION
Removing the closing tag is kind of "good practice" referring to many coding guidelines.