### PR TITLE
CSSTidy Transition property

### DIFF
--- a/lib/CSSTidy/class.csstidy_optimise.php
+++ b/lib/CSSTidy/class.csstidy_optimise.php
@@ -400,9 +400,9 @@ class csstidy_optimise {
 				if ($number[1] == '' && in_array($this->property, $unit_values, true)) {
 					$number[1] = 'px';
 				}
-            } elseif ($number[1] != 's' && $number[1] != 'ms') {
-                $number[1] = '';
-            }
+                        } elseif ($number[1] != 's' && $number[1] != 'ms') {
+                                $number[1] = '';
+                        }
 
 			$temp[$l] = $number[0] . $number[1];
 		}

--- a/lib/CSSTidy/class.csstidy_optimise.php
+++ b/lib/CSSTidy/class.csstidy_optimise.php
@@ -400,9 +400,9 @@ class csstidy_optimise {
 				if ($number[1] == '' && in_array($this->property, $unit_values, true)) {
 					$number[1] = 'px';
 				}
-			} else {
-				$number[1] = '';
-			}
+            } elseif ($number[1] != 's' && $number[1] != 'ms') {
+                $number[1] = '';
+            }
 
 			$temp[$l] = $number[0] . $number[1];
 		}

--- a/lib/CSSTidy/class.csstidy_optimise.php
+++ b/lib/CSSTidy/class.csstidy_optimise.php
@@ -400,9 +400,9 @@ class csstidy_optimise {
 				if ($number[1] == '' && in_array($this->property, $unit_values, true)) {
 					$number[1] = 'px';
 				}
-                        } elseif ($number[1] != 's' && $number[1] != 'ms') {
-                                $number[1] = '';
-                        }
+            } elseif ($number[1] != 's' && $number[1] != 'ms') {
+                $number[1] = '';
+            }
 
 			$temp[$l] = $number[0] . $number[1];
 		}


### PR DESCRIPTION
This resolves an issue with csstidy using the _transition_ property where it would strip the "s" or "ms" from 0 .. e.g. "_0s_" becomes "_0_".  It would only happen for "_0_" not "_0.4s_" (that would remain as "_0.4s_", for example.  

According to the standard and browser tests, the _transition_ property fails because of the missing unit.