### PR TITLE
minify.css.embed_content not working

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -188,6 +188,22 @@ function w3_filename_to_url($filename, $use_site_url = false) {
     return $url;
 }
 
+/*
+ * Returns filename/dirname from URI
+ *
+ * @return string|false
+ */
+function w3_url_to_filename($url) {
+
+	$filename = ABSPATH . str_replace('/', DIRECTORY_SEPARATOR, ltrim(parse_url($url, PHP_URL_PATH), '/'));
+	
+	if( !file_exists($filename) ){
+		$filename = false;
+	}
+	 
+	return $filename;
+}
+
 /**
  * Returns true if database cluster is used
  *

--- a/lib/W3/Plugin/Minify.php
+++ b/lib/W3/Plugin/Minify.php
@@ -662,7 +662,12 @@ class W3_Plugin_Minify extends W3_Plugin {
 
         $content = "";
         if ($this->_config->get_boolean('minify.css.embed_content')) {
-           $content = @file_get_contents($url);
+           if($filename = w3_url_to_filename($url)){
+               $content = @file_get_contents($filename);
+           } else {
+           	   // A URL can be used as a filename with this function if the fopen wrappers have been enabled. 
+           	   $content = @file_get_contents($url);
+           }
         }
         
         if ($import && $use_style) {

--- a/lib/W3/Plugin/Minify.php
+++ b/lib/W3/Plugin/Minify.php
@@ -665,7 +665,6 @@ class W3_Plugin_Minify extends W3_Plugin {
            if($filename = w3_url_to_filename($url)){
                $content = @file_get_contents($filename);
            } else {
-           	   // A URL can be used as a filename with this function if the fopen wrappers have been enabled. 
            	   $content = @file_get_contents($url);
            }
         }


### PR DESCRIPTION
minify.css.embed_content not works ever, the problem is ` @file_get_contents($url);` ([here](https://github.com/szepeviktor/w3-total-cache-fixed/blob/v0.9.4.x/lib/W3/Plugin/Minify.php#L665)):
```php
    if ($this->_config->get_boolean('minify.css.embed_content')) {
        $content = @file_get_contents($url);
    }
```
from [docs](http://php.net/manual/en/function.file-get-contents.php):

> Tip A URL can be used as a filename with this function if the fopen wrappers have been enabled. See fopen() for more details on how to specify the filename. See the Supported Protocols and Wrappers for links to information about what abilities the various wrappers have, notes on their usage, and information on any predefined variables they may provide.

in this pr i try to convert the url into filename:
```php
    if ($this->_config->get_boolean('minify.css.embed_content')) {
        if($filename = w3_url_to_filename($url)){
            $content = @file_get_contents($filename);
        } else {
            $content = @file_get_contents($url);
        }
    }
```
it also have a performance improvements because php read from disk instead of makes http request.

i have also add `w3_url_to_filename` into w3tc api.