### PR TITLE
Auto - JS Embed Type being Ignored

### DIFF
--- a/lib/W3/Plugin/Minify.php
+++ b/lib/W3/Plugin/Minify.php
@@ -1291,8 +1291,6 @@ class _W3_MinifyJsAuto {
         // define embed type
         $this->embed_type = $this->config->get_string(
             'minify.js.header.embed_type');
-        if ($this->embed_type != 'extsrc' && $this->embed_type != 'asyncsrc' && $this->embed_type != 'inline')
-            $this->embed_type = 'blocking';
     }
 
     /**


### PR DESCRIPTION
For some unknown author reason i noticed that when using Auto (minify) mode the JS Embed Type (under Minify tab) is ignored internally (it changes it to "blocking") despite allowing the user to select non-blocking
types, giving the wrong impression that one can use non-blocking types.

If it's because "_Auto_" should always imply that it handles embed types too then it doesn't explain why this drop-down box isn't disabled.  

So, this commit just removes the restriction so the user's embed type selection isn't being ignore when using Auto.