### PR TITLE
PgCache_ContentGrabber not checking for uncompressed cache

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -246,7 +246,7 @@ class PgCache_ContentGrabber {
 		 * Try to get uncompressed version of cache
 		 */
 		if ( $compression && !$data ) {
-			if ( $this->_set_extract_page_key( $mobile_group,
+			if ( !$this->_set_extract_page_key( $mobile_group,
 					$referrer_group, $encryption, false, '', $with_filter ) ) {
 				$data = null;
 			} else {


### PR DESCRIPTION
from official support forum [topic](https://wordpress.org/support/topic/pgcache_contentgrabber-not-checking-for-uncompressed-cache/#post-8629473):
> Currently when a page is cached uncompressed but not compressed then $data will be set to null when successfully setting the uncompressed page cache key.

on line [237](https://github.com/szepeviktor/w3-total-cache-fixed/blob/v0.9.5.x/PgCache_ContentGrabber.php#L237) w3tc check for the compressed page:

```php
if ( !$this->_set_extract_page_key( $mobile_group, $referrer_group, $encryption, $compression, '', $with_filter ) ) {
   $data = null;
} else { 
    $data = $cache->get_with_old( $this->_page_key, $group );
    list( $data, $this->_old_exists ) = $data;
}
```
instead on line [249](https://github.com/szepeviktor/w3-total-cache-fixed/blob/v0.9.5.x/PgCache_ContentGrabber.php#L249) check for the uncompressed page:

```php
if ( $this->_set_extract_page_key( $mobile_group, $referrer_group, $encryption, false, '', $with_filter ) ) {
    $data = null;
} else {
    $data = $cache->get_with_old( $this->_page_key );
    list( $data, $this->_old_exists ) = $data;
    $compression = false;
}
```
it seems the opposite check! there seems to be a typo / mistake as the `!` is missing.

I’m not 100% sure of the situation that causes a uncompressed page only to be cached. I need help for confirm this pr. Anyone on v0.9.5.x?