### PR TITLE
Fix issue on verify minify rewrite rule working

### DIFF
--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -261,6 +261,7 @@ class Minify_Environment {
 	 * @return boolean
 	 */
 	private function test_rewrite( $url ) {
+		$url = str_replace('\\', '/', $url);
 		$key = sprintf( 'w3tc_rewrite_test_%s', substr( md5( $url ), 0, 16 ) );
 		$result = get_site_transient( $key );
 

--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -261,7 +261,7 @@ class Minify_Environment {
 	 * @return boolean
 	 */
 	private function test_rewrite( $url ) {
-		$url = str_replace('\\', '/', $url);
+		
 		$key = sprintf( 'w3tc_rewrite_test_%s', substr( md5( $url ), 0, 16 ) );
 		$result = get_site_transient( $key );
 

--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -119,8 +119,9 @@ class Util_Environment {
 			return '';
 		$uri_from_wp_content = substr( $filename, strlen( WP_CONTENT_DIR ) );
 		$url = content_url( $uri_from_wp_content );
+		$url = str_replace('\\', '/', $url);
 		$url = apply_filters( 'w3tc_filename_to_url', $url );
-
+		
 		return $url;
 	}
 


### PR DESCRIPTION
After enable Minify, W3 Total Cache make a test for check if minify  rewrite rule working. Sometime the test fail:

> W3 Total Cache error:It appears Minify URL rewriting is not working. Please verify that the server configuration allows .htaccess
Unfortunately minification will not function without custom rewrite rules. Please ask your server administrator for assistance. Also refer to the install page for the rules for your server.
Technical info
.htaccess file contains rules to rewrite url http://wordpress/wp-content/cache\minify\0/14881w3tc_rewrite_test.css. If handled by plugin, it returns "OK" message.
The plugin made a request to http://wordpress/wp-content/cache\minify\0/14881w3tc_rewrite_test.css but received: 
404 Not Found
instead of "OK" response. 

the request failed because the url contain `\` instead of `/`.

the problem is into:
```php
/*
* Returns URI from filename/dirname
*
* @return string
*/
static public function filename_to_url( $filename, $use_site_url = false ) {
    // using wp-content instead of document_root as known dir since dirbased
    // multisite wp adds blogname to the path inside site_url
    if ( substr( $filename, 0, strlen( WP_CONTENT_DIR ) ) != WP_CONTENT_DIR )
        return '';
    $uri_from_wp_content = substr( $filename, strlen( WP_CONTENT_DIR ) );
    $url = content_url( $uri_from_wp_content );
    $url = apply_filters( 'w3tc_filename_to_url', $url );
		
    return $url;
}
```
it only transform path in url without change the drive directory separator (`\`) with the url directory separator (`/`). The fix is a siple string replace `$url = str_replace('\\', '/', $url);`:
```php
/*
* Returns URI from filename/dirname
*
* @return string
*/
static public function filename_to_url( $filename, $use_site_url = false ) {
    // using wp-content instead of document_root as known dir since dirbased
    // multisite wp adds blogname to the path inside site_url
    if ( substr( $filename, 0, strlen( WP_CONTENT_DIR ) ) != WP_CONTENT_DIR )
        return '';
    $uri_from_wp_content = substr( $filename, strlen( WP_CONTENT_DIR ) );
    $url = content_url( $uri_from_wp_content );
    $url = str_replace('\\', '/', $url);
    $url = apply_filters( 'w3tc_filename_to_url', $url );
		
    return $url;
}
```