### PR TITLE
Remove SVG from HTML mime

### DIFF
--- a/inc/mime/html.php
+++ b/inc/mime/html.php
@@ -6,7 +6,6 @@
 return array(
 	'html|htm' => 'text/html',
 	'rtf|rtx' => 'text/richtext',
-	'svg|svgz' => 'image/svg+xml',
 	'txt' => 'text/plain',
 	'xsd' => 'text/xsd',
 	'xsl' => 'text/xsl',


### PR DESCRIPTION
from https://github.com/szepeviktor/w3-total-cache-fixed/issues/242

The issue:
>Right now, svg files have the same cache settings as html files for max-age. Strangely expiry is that of image files.
>svg fonts are no longer in use but svg's usage is rising both for images and for emoji. (Example usage: self-hosting Twemoji).
>So I think it makes sense to make the cache setting for emoji files the same as image files.

The fix:
>I believe the problem (and solution) revolves aorund inc/mime/html.php. I notice: 'svg|svgz' => 'image/svg+xml', which is causing svg (and svgz) to appear in htaccess twice..one using html's expires/max-age and another (lower in the htaccess) for "Media & Other files" expires/max-age. Seems one just has to strip out that line from the html.php to fix the problem. The same is true for rtf and rtx.