### PR TITLE
Fix bad css and string offset

### DIFF
--- a/inc/mime/html.php
+++ b/inc/mime/html.php
@@ -6,7 +6,6 @@
 return array(
 	'html|htm' => 'text/html',
 	'rtf|rtx' => 'text/richtext',
-	'svg|svgz' => 'image/svg+xml',
 	'txt' => 'text/plain',
 	'xsd' => 'text/xsd',
 	'xsl' => 'text/xsl',

--- a/lib/Minify/Minify/CSS/UriRewriter.php
+++ b/lib/Minify/Minify/CSS/UriRewriter.php
@@ -209,7 +209,7 @@ class Minify_CSS_UriRewriter {
      */
     private static function rewriteRelative($uri, $realCurrentDir, $realDocRoot, $symlinks = array())
     {
-        if ( isset($uri[0]) && '/' === $uri[0]) { // root-relative
+        if ('/' === substr($uri, 0, 1)) { // root-relative
             return $uri;
         }
 
@@ -376,7 +376,8 @@ class Minify_CSS_UriRewriter {
                 : substr($m[1], 1, strlen($m[1]) - 2);
         }
         // analyze URI
-        if ('/' !== $uri[0]                  // root-relative
+        if (   !empty($uri)                  // bad css, eg: @import url();
+        	&& '/' !== substr($uri, 0, 1)    // root-relative
             && false === strpos($uri, '//')  // protocol (non-data)
             && 0 !== strpos($uri, 'data:')   // data protocol
         ) {
@@ -399,7 +400,7 @@ class Minify_CSS_UriRewriter {
                 if (!\W3TC\Util_Environment::is_url(self::$_prependPath)) {
 					$uri = self::$_prependPath . $uri;
 
-                    if ($uri[0] === '/') {
+                    if (substr($uri, 0, 1) === '/') {
                         $root = '';
                         $rootRelative = $uri;
                         $uri = $root . self::removeDots($rootRelative);


### PR DESCRIPTION
from https://wordpress.org/support/topic/uninitialized-string-offset-cssurirewriter-php/

bad css code like `@import url();` or `background-image: url();` cause error during minification/combination that destroy all process.

this happened because w3tc expect the uri into the css `url()` is not empty:

```php
// analyze URI
if ('/' !== $uri[0]                 // root-relative
   && false === strpos($uri, '//')  // protocol (non-data)
   && 0 !== strpos($uri, 'data:')   // data protocol
)
```

but if  `$uri` is empty,  `$uri[0]`  raise this exception

> PHP Notice:  Uninitialized string offset: 0 in \w3-total-cache\lib\Minify\Minify\CSS\UriRewriter.php on line 379

this fix simple check for non-empty uri:

```php
if ( !empty($uri)                     // bad css, eg: @import url();
     && '/' !== substr($uri, 0, 1)    // root-relative
     && false === strpos($uri, '//')  // protocol (non-data)
     && 0 !== strpos($uri, 'data:')   // data protocol
)
```
i have also replace `$uri[0]` with `substr($uri, 0, 1)`, are the same, substr is more affordable (on empty string return false) but a bit slower.