### PR TITLE
Admin textarea error on print new-line

### DIFF
--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -602,7 +602,7 @@ class Util_Ui {
 		if ( !isset( $a['value'] ) || is_null( $a['value'] ) ) {
 			$a['value'] = $c->get( $a['key'] );
 			if ( is_array( $a['value'] ) )
-				$a['value'] = implode( '\n', $a['value'] );
+				$a['value'] = implode( "\n", $a['value'] );
 		}
 
 		if ( isset( $a['disabled'] ) && !is_null( $a['disabled'] ) )


### PR DESCRIPTION
from https://wordpress.org/support/topic/aliases-additional-home-urls/

After entering additional home URLs, when the page is re-displayed, the values are shown on a single line with `\n` between them.

If you enter
```
http://my-site.com
http://www.my-site.com
```
you get
`http://my-site.com\nhttp://www.my-site.com`

the problem is w3tc print `'\n'` instead print new-line `"\n"`