### PR TITLE
Filename to uri return uri with // at beginning

### DIFF
--- a/Util_Rule.php
+++ b/Util_Rule.php
@@ -14,8 +14,9 @@ class Util_Rule {
 		$url = Util_Environment::filename_to_url( $filename );
 		$parsed = parse_url( $url );
 		$uri = isset( $parsed['path'] ) ? ltrim( $parsed['path'], DIRECTORY_SEPARATOR ) : '';
-		$uri = '/' . $uri;
-
+		if( strpos($uri, '/') !== 0 ){
+		    $uri = '/' . $uri;
+		}
 		return $uri;
 	}
 

--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -602,7 +602,7 @@ class Util_Ui {
 		if ( !isset( $a['value'] ) || is_null( $a['value'] ) ) {
 			$a['value'] = $c->get( $a['key'] );
 			if ( is_array( $a['value'] ) )
-				$a['value'] = implode( '\n', $a['value'] );
+				$a['value'] = implode( "\n", $a['value'] );
 		}
 
 		if ( isset( $a['disabled'] ) && !is_null( $a['disabled'] ) )


### PR DESCRIPTION
filename to uri return uri with `/ `at beginning, see `$uri = '/' . $uri;`

```php
static public function filename_to_uri( $filename ) {
    $url = Util_Environment::filename_to_url( $filename );
    $parsed = parse_url( $url );
    $uri = isset( $parsed['path'] ) ? ltrim( $parsed['path'], DIRECTORY_SEPARATOR ) : '';
    $uri = '/' . $uri;

    return $uri;
}
```
sometimes the result is a `//` at beginning. The fix is add a `/` at beginning only if not exists:
```php
static public function filename_to_uri( $filename ) {
    $url = Util_Environment::filename_to_url( $filename );
    $parsed = parse_url( $url );
    $uri = isset( $parsed['path'] ) ? ltrim( $parsed['path'], DIRECTORY_SEPARATOR ) : '';
    if( strpos($uri, '/') !== 0 ){
        $uri = '/' . $uri;
    }

    return $uri;
}
```
