### PR TITLE
_get_page_key return wrong key for PgCache.

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1037,14 +1037,16 @@ class PgCache_ContentGrabber {
 	 */
 	function _get_page_key( $mobile_group = '', $referrer_group = '',
 		$encryption = '', $compression = '', $content_type = '', $request_url = '' ) {
-
-		if ( $request_url ) {
-			$parts = parse_url( $request_url );
-			$key = $parts['host'] .
-				( isset( $parts['path'] ) ? $parts['path'] : '' ) .
-				( isset( $parts['query'] ) ? '?' . $parts['query'] : '' );
-		} else
-			$key = $this->_request_host . $this->_request_uri;
+		
+		$key = '';
+			
+		if( empty($request_url) ){
+			$request_url = 'http://'.$this->_request_host . $this->_request_uri;
+		}
+		
+		if( $parts = @parse_url( $request_url ) ){
+			$key = $parts['host'] . (isset($parts['path']) ? substr($parts['path'], 0, strrpos($parts['path'], '/') + 1) : '');
+		}
 
 		// replace fragment
 		$key = preg_replace( '~#.*$~', '', $key );


### PR DESCRIPTION
`_get_page_key` return wrong key because always add a suffix `_index` without remove filename or query string to the request url. 

On request url like:

    http://www.wordpress.local/wp-content/cache/minify/0/0123.css

the result is 

    http://www.wordpress.local/wp-content/cache/minify/0/0123.css/_index.html

i'm not sure, 100% correct. 

