### PR TITLE
make default -MultiViews

### DIFF
--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -538,9 +538,9 @@ class Minify_Environment {
 
 		$rules = '';
 		$rules .= W3TC_MARKER_BEGIN_MINIFY_CACHE . "\n";
-		if ( $compatibility ) {
-			$rules .= "Options -MultiViews\n";
-		}
+		$rules .= "<IfModule mod_negotiation.c>\n";
+		$rules .= "    Options -MultiViews\n";
+		$rules .= "</IfModule>\n";
 
 		if ( $etag ) {
 			$rules .= "FileETag MTime Size\n";


### PR DESCRIPTION
**TL;DR**
Minify cache not works with `+Multiviews`

**Details**

issue https://github.com/szepeviktor/w3-total-cache-fixed/issues/287

from Apache error log:

> [Sun Jan 15 19:31:39.808370 2017] [negotiation:error] [pid 7248:tid 2264] [client 127.0.0.1:60075] AH00687: Negotiation: discovered file(s) matching request: /wordpress/wp-content/cache/minify/1/985ff.js (None could be negotiated).

in the vhosts (note `+Multiviews`):

```
<VirtualHost 127.0.0.1:*>
    DocumentRoot "/wordpress/"
	
    <Directory /wordpress>
        DirectoryIndex index.php
        Options -Indexes +FollowSymLinks +MultiViews
        AllowOverride All
        Require all granted
    </Directory>
</VirtualHost>
```
from [docs](https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html):

>  A Multiviews search (enabled by the Multiviews Options), where the server does an implicit filename pattern match, and choose from amongst the results.

w3tc v0.9.5.x add `-MultiViews` only if compatibility mode is checked [Minify_Environment.php#L542](https://github.com/szepeviktor/w3-total-cache-fixed/blob/v0.9.5.x/Minify_Environment.php#L542):

```php
$rules .= W3TC_MARKER_BEGIN_MINIFY_CACHE . "\n";
if ( $compatibility ) {
    $rules .= "Options -MultiViews\n";
}
```
but v0.9.4.x add it always [MinifyAdminEnvironment.php#L539](https://github.com/szepeviktor/w3-total-cache-fixed/blob/v0.9.4.x/lib/W3/MinifyAdminEnvironment.php#L539):
```php
$rules .= W3TC_MARKER_BEGIN_MINIFY_CACHE . "\n";
$rules .= "Options -MultiViews\n";
```
`mod_negotiation` is a [default module of Apache](https://en.wikipedia.org/wiki/List_of_Apache_modules)

My proposal is revert to v0.9.4.x's approach with a tiny control:

```php
$rules .= W3TC_MARKER_BEGIN_MINIFY_CACHE . "\n";
$rules .= "<IfModule mod_negotiation.c>\n";
$rules .= "    Options -MultiViews\n";
$rules .= "</IfModule>\n";
```
because `+MultiViews` is a common setting in so many hosting.