### PR TITLE
Deprecated function / exclude git .md files from zips

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,7 @@
 bin export-ignore
 README.md export-ignore
 LICENSE export-ignore
+ISSUE_TEMPLATE.md export-ignore
+PULL_REQUEST_TEMPLATE.md export-ignore
 tests export-ignore
 phpunit.xml.dist export-ignore

--- a/lib/W3/Plugin/Minify.php
+++ b/lib/W3/Plugin/Minify.php
@@ -631,7 +631,6 @@ class W3_Plugin_Minify extends W3_Plugin {
                 case (is_author() && ($template_file = get_author_template())):
                 case (is_date() && ($template_file = get_date_template())):
                 case (is_archive() && ($template_file = get_archive_template())):
-                case (is_comments_popup() && ($template_file = get_comments_popup_template())):
                 case (is_paged() && ($template_file = get_paged_template())):
                     break;
 


### PR DESCRIPTION
removal of a few deprecated functions: `is_comments_popup` and `get_comments_popup_template` that no longer serve any purpose in w3tc.  Both were deprecated since wp 4.5 and always return false.

