### PR TITLE
Abstract Static Fuction

### DIFF
--- a/lib/Minify/Minify/Inline.php
+++ b/lib/Minify/Minify/Inline.php
@@ -5,8 +5,6 @@ abstract class Minify_Inline {
     protected $_minifier = null;
     protected $_minifierOptions = array();
 
-    abstract static function minify($content, $minifier, $options = array());
-
     public function setTag($tag) {
         $this->_tag = $tag;
     }


### PR DESCRIPTION
Although abstract static functions are allowed to be used in PHP 7.x, in PHP 5.4-5.6 it is not permitted.  I believe it was never a problem before because one needs to enable php strict mode to see the error.  

The solution is simple:  Just remove the abstract static function line because it is not necessary.  The minify() function is implemented properly in all the right places and so there is no need for this
abstract at all.