### PR TITLE
Gzip Cached Pages are not Decoding

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1241,7 +1241,7 @@ class PgCache_ContentGrabber {
 		// headers are sent as name->value and array(n=>, v=>)
 		// to support repeating headers
 		foreach ( $headers as $name0 => $value0 ) {
-			if ( isset( $value0['n'] ) ) {
+			if ( is_array($value0) && isset( $value0['n'] ) ) {
 				$name = $value0['n'];
 				$value = $value0['v'];
 			} else {


### PR DESCRIPTION
This fix resolves a critical issue discussed at #312 whereby headers are being sent back incorrectly.  This has a dramatic effect when gzip'ed cached pages are sent back to the client browser -- they are unable to be decoded and thus, pages show up all garbled.  More accurately, the client browser is just raw outputting the gzip'ed content on-screen instead of decoding it.

Although my tests showed that this problem only occurs in PHP 5.3 (and lower) some people using 5.6.29 (it was rare) had reported that they saw the same problem and that this fix worked for them as well.

## Why the Problem Occurs

What is happening is PHP 5.3's (and lower) _isset()_ function interprets the parameter given (ie, _$value0['n']_) as a string of characters not a placeholder for an array and so the _isset()_ ends up being TRUE. And the index value of `'n'` ends up being index 0 into this string. What that does is it returns the first letter of the header's value back to the user e.g. _"Cache-Control: max-age=3600, public"_ becomes _"m: m"_. This peculiar behavior doesn't occur in PHP 5.4 and higher. :octocat: 

![gzip](https://cloud.githubusercontent.com/assets/5191497/22234455/5c0c1cc2-e1c6-11e6-8836-10915719e28a.png)
