### PR TITLE
Using uploads_dir Placeholder in CDN Custom File list Breaks Page

### DIFF
--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -1007,10 +1007,12 @@ class _Cdn_Plugin_ContentFilter {
 				foreach ( $masks as $mask ) {
 					if ( !empty( $mask ) ) {
 						if ( Util_Environment::is_url( $mask ) ) {
-                            $parse_url = @parse_url( $mask );
-                            $mask = $parse_url["path"];			
-                            $domain_url = Util_Environment::get_url_regexp( sprintf( '%s://%s%s', $parse_url['scheme'], $parse_url['host'], ( isset( $parse_url['port'] ) && $parse_url['port'] != 80 ? ':' . (int) $parse_url['port'] : '' ) ) );
-                            $custom_regexps_urls[] = array('domain' => $domain_url, 'path' => Cdn_Util::get_regexp_by_mask( $mask ));
+							$parse_url = @parse_url( $mask );
+                            if ( $parse_url && isset( $parse_url['host'] ) ) {
+								$mask = $parse_url["path"];			
+								$domain_url = Util_Environment::get_url_regexp( sprintf( '%s://%s%s', ( isset( $parse_url['scheme'] ) ? $parse_url['scheme']:'' ), $parse_url['host'], ( isset( $parse_url['port'] ) && $parse_url['port'] != 80 ? ':' . (int) $parse_url['port'] : '' ) ) );
+								$custom_regexps_urls[] = array('domain' => $domain_url, 'path' => Cdn_Util::get_regexp_by_mask( $mask ));
+                            }
 						} elseif ( substr( $mask, 0, 1 ) == '/' ) {   // uri
 							$custom_regexps_uris[] = Cdn_Util::get_regexp_by_mask( $mask );
 						} else {

--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -1007,7 +1007,10 @@ class _Cdn_Plugin_ContentFilter {
 				foreach ( $masks as $mask ) {
 					if ( !empty( $mask ) ) {
 						if ( Util_Environment::is_url( $mask ) ) {
-							$custom_regexps_urls[] = Cdn_Util::get_regexp_by_mask( $mask );
+                            $parse_url = @parse_url( $mask );
+                            $mask = $parse_url["path"];			
+                            $domain_url = Util_Environment::get_url_regexp( sprintf( '%s://%s%s', $parse_url['scheme'], $parse_url['host'], ( isset( $parse_url['port'] ) && $parse_url['port'] != 80 ? ':' . (int) $parse_url['port'] : '' ) ) );
+                            $custom_regexps_urls[] = array('domain' => $domain_url, 'path' => Cdn_Util::get_regexp_by_mask( $mask ));
 						} elseif ( substr( $mask, 0, 1 ) == '/' ) {   // uri
 							$custom_regexps_uris[] = Cdn_Util::get_regexp_by_mask( $mask );
 						} else {
@@ -1022,7 +1025,8 @@ class _Cdn_Plugin_ContentFilter {
 
 				if ( count( $custom_regexps_urls ) > 0 ) {
 					foreach ( $custom_regexps_urls as $regexp )
-						$regexps[] = '~(["\'(=])\s*((' . $regexp . ')?(()([^"\'() >]*)))~i';
+                        $regexps[] = '~(["\'(=])\s*((' . $regexp['domain'] .
+                            ')?((' . $regexp['path'] . ')([^"\'() >]*)))~i';
 				}
 				if ( count( $custom_regexps_uris ) > 0 ) {
 					$regexps[] = '~(["\'(=])\s*((' . $domain_url_regexp .


### PR DESCRIPTION
CDN Generic Mirror doesn't work with "{uploads_dir}/*" in Custom file list as discussed in #296.

The problem is that the `{uploads_dir}` placeholder when converted is becoming a full url (e.g. http://mydomain.com/wp-contents/uploads/* ) -- unlike `{wp_content_dir}` and `{plugins_dir}` which are filesystem paths not urls -- and so, upon closer inspection it seems full urls in the Custom Files list such as http://foo.bar/* are mishandled.

This fix tries to remedy that (and the `{uploads_dir}` issue) by handling full urls more correctly so that when the CDN host name is used in the page it can properly replace any given domain (if given in the custom files list).