### PR TITLE
CDN Custom Files Issue with Full Urls

### DIFF
--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -1007,8 +1007,10 @@ class _Cdn_Plugin_ContentFilter {
 				foreach ( $masks as $mask ) {
 					if ( !empty( $mask ) ) {
 						if ( Util_Environment::is_url( $mask ) ) {
-							$custom_regexps_urls[] = Cdn_Util::get_regexp_by_mask( $mask );
-						} elseif ( substr( $mask, 0, 1 ) == '/' ) {   // uri
+							$mask = Util_Environment::url_to_uri( $mask );
+						}
+						
+						if ( substr( $mask, 0, 1 ) == '/' ) {   // uri
 							$custom_regexps_uris[] = Cdn_Util::get_regexp_by_mask( $mask );
 						} else {
 							$file = Util_Environment::normalize_path( $mask );   // \ -> backspaces


### PR DESCRIPTION
When full urls (e.g. http://mydomain.com/uploads/* ) are used in the _Custom File List_ box (of CDN tab) it causes the page to break (see attached image below -- it shows the page source code).  This issue was discovered because the `{uploads_dir}` placeholder when converted was becoming a full url (e.g. _{uploads_dir}_ = http://mydomain.com/uploads/* ) instead of being just its path (e.g. /uploads/* ) like `{wp_content_dir}` and `{plugins_dir}` when they're converted.  As such, this fix indirectly resolves the `{upload_dir}/*` issue (#296).  It also goes further by taking care of cases where the user could enter a full url unrelated to _{uploads_dir}_.

## Why the Problem Occurs

It's because the regex that handles full urls is not correctly implemented.  Relative path urls only work. On further inspection it appears the CDN page is purposely designed for local files only. Knowing that, this fix simply strips full urls down to their paths for processing.

If it turns out that remote (foreign) full urls are indeed permitted (not just local domain full urls) in the _Custom File List_ box then the regex that handles full urls at line #1027 will need to be fixed.

Incidentally, an **alternate working fix already exists which handles both local and foreign full urls** and can be found at: https://github.com/szepeviktor/w3-total-cache-fixed/pull/314/files.

Despite working perfectly, this alternate fix was not merged into the branch because we got the impression that the CDN tab's _Custom File List_ box is for local files only, even though internally the code shows there is a clear path for handling full urls.  It's just buggy.  **Feel free to use the alternate fix instead if full urls are indeed allowed in this box.** :octocat: 

![custom](https://cloud.githubusercontent.com/assets/5191497/22234661/c3af1202-e1c7-11e6-820a-ca19eef44cfc.png)
