### PR TITLE
Google PageSpeed Widget - Added Referrer Key Restriction Field

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -1767,6 +1767,10 @@ $keys = array(
 		'type' => 'string',
 		'default' => ''
 	),
+    'widget.pagespeed.key.restrict.referrer' => array(
+        'type' => 'string',
+        'default' => ''
+    ),
 	'widget.pagespeed.show_in_admin_bar' => array(
 		'type' => 'boolean',
 		'default' => false

--- a/Generic_AdminActions_Test.php
+++ b/Generic_AdminActions_Test.php
@@ -204,7 +204,9 @@ class Generic_AdminActions_Test {
 
 		$config = Dispatcher::config();
 		$key = $config->get_string( 'widget.pagespeed.key' );
-		$w3_pagespeed = new PageSpeed_Api( $key );
+		$ref = $config->get_string( 'widget.pagespeed.key.restrict.referrer' );
+		
+		$w3_pagespeed = new PageSpeed_Api( $key, $ref );
 
 		$results = $w3_pagespeed->analyze( get_home_url() );
 		include W3TC_INC_POPUP_DIR . '/pagespeed_results.php';

--- a/Generic_ConfigLabels.php
+++ b/Generic_ConfigLabels.php
@@ -11,6 +11,7 @@ class Generic_ConfigLabels {
 				'cluster.messagebus.sns.topic_arn' => __( 'Topic <acronym title="Identification">ID</acronym>:', 'w3-total-cache' ),
 				'cluster.messagebus.debug' =>  __( 'Message Bus', 'w3-total-cache' ),
 				'widget.pagespeed.key' => __( 'Page Speed <acronym title="Application Programming Interface">API</acronym> Key:', 'w3-total-cache' ),
+				'widget.pagespeed.key.restrict.referrer' => __( 'Key Restriction (Referrer):', 'w3-total-cache' ),
 				'common.force_master' => __( 'Use single network configuration file for all sites.', 'w3-total-cache' ),
 				'config.path' => __( 'Nginx server configuration file path', 'w3-total-cache' ),
 				'config.check' => __( 'Verify rewrite rules', 'w3-total-cache' ),

--- a/PageSpeed_Api.php
+++ b/PageSpeed_Api.php
@@ -17,11 +17,19 @@ class PageSpeed_Api {
 	 */
 	var $key = '';
 
+    /**
+     * Referrer for key restricting
+     *
+     * @var string
+     */
+    var $key_restrict_referrer = '';
+
 	/**
 	 * PHP5-style constructor
 	 */
-	function __construct( $api_key ) {
+	function __construct( $api_key, $api_ref ) {
 		$this->key = $api_key;
+		$this->key_restrict_referrer = $api_ref;
 	}
 
 	/**
@@ -51,7 +59,9 @@ class PageSpeed_Api {
 				'key' => $this->key,
 			) );
 
-		$response = Util_Http::get( $request_url, array( 'timeout' => 120 ) );
+		$response = Util_Http::get( $request_url, array( 'timeout' => 120,
+													 'headers' => array( "Referer" => $this->key_restrict_referrer )
+													) );
 		if ( !is_wp_error( $response ) && $response['response']['code'] == 200 ) {
 			return $response['body'];
 		}

--- a/PageSpeed_Plugin_Widget.php
+++ b/PageSpeed_Plugin_Widget.php
@@ -90,8 +90,9 @@ class PageSpeed_Plugin_Widget {
 
 		$config = Dispatcher::config();
 		$key = $config->get_string( 'widget.pagespeed.key' );
-
-		$w3_pagespeed = new PageSpeed_Api( $key );
+		$ref = $config->get_string( 'widget.pagespeed.key.restrict.referrer' );
+		
+		$w3_pagespeed = new PageSpeed_Api( $key, $ref );
 		$r = $w3_pagespeed->analyze( get_home_url() );
 
 		if ( !$r ) {
@@ -131,7 +132,8 @@ class PageSpeed_Plugin_Widget {
 
 		$config = Dispatcher::config();
 		$key = $config->get_string( 'widget.pagespeed.key' );
-		$w3_pagespeed = new PageSpeed_Api( $key );
+		$ref = $config->get_string( 'widget.pagespeed.key.restrict.referrer' );
+		$w3_pagespeed = new PageSpeed_Api( $key, $ref );
 
 		$r = $w3_pagespeed->analyze( $url );
 

--- a/inc/options/general.php
+++ b/inc/options/general.php
@@ -431,6 +431,13 @@ Util_Ui::config_item( array(
                     Then go to the <acronym title="Application Programming Interface">API</acronym> Access tab. The <acronym title="Application Programming Interface">API</acronym> key is in the Simple <acronym title="Application Programming Interface">API</acronym> Access section.', 'w3-total-cache' ); ?></span>
                 </td>
             </tr>
+            <tr>
+                <th><label for="widget_pagespeed_key"><?php Util_Ui::e_config_label( 'widget.pagespeed.key.restrict.referrer', 'general' ) ?></label></th>
+                <td>
+                    <input id="widget_pagespeed_key_restrict_referrer" type="text" name="widget__pagespeed__key__restrict__referrer" value="<?php echo esc_attr( $this->_config->get_string( 'widget.pagespeed.key.restrict.referrer' ) ); ?>" size="60" /><br>
+                    <span class="description">Although not required, to prevent unauthorized use and quota theft, you have the option to restrict your key using a designated HTTP referrer. If you decide to use it, you will need to set this referrer within the API Console's "Http Referrers (web sites)" key restriction area (under Credentials).</span>
+                </td>
+            </tr>            
             <?php
 Util_Ui::config_item( array(
 		'key' => 'widget.pagespeed.show_in_admin_bar',


### PR DESCRIPTION
Included a feature to allow users to provide an optional http referrer (via a new input field called **Key Restriction (Referrer)** found under the _General Settings > Miscellaneous > Google PageSpeed Dashboard Widget_ area) which can be set up to be used as a key restriction parameter for the PageSpeed console's credentials area.  This resolves an issue some were having when using the PageSpeed widget.  More specifically, they wanted this option to help reduce unauthorized access through their API key. :octocat: 

![pagespeed_key_restriction_referrer](https://cloud.githubusercontent.com/assets/5191497/18574146/078f11f2-7b98-11e6-8559-4381d42873ea.jpg)