### PR TITLE
Page Cache - New Fields (Adjustment)

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -615,7 +615,7 @@ class PgCache_ContentGrabber {
 			return false;
 		}
 
-        if ( !$this->_check_cache_exception() ) {
+        if ( !$this->_check_cache_exception() && ( is_single() || is_page() ) ) {
 			if ( is_single() ) {
                 /**
                  * Don't cache pages associated with categories


### PR DESCRIPTION
This is adjustment is dependent on PR #319.  The new fields only affect posts and pages.  I had forgotten to do an early check to ensure we are dealing with either type before processing the request against each new field.

Prior to this adjustment this could have led to non-post/page types not being cached because some share the same underlying meta detail that the new fields were checking against.

For example, an author page (the page showing a summary of their collective works) and an author's individual posts share the same meta detail of being done by the same author.  If using the new `Never Cache Pages By These Authors` field to not cache pages/posts by a particular author (by providing the author's username) then that author's posts will not be cached, but his/her summary page will be cached (assuming it was not provided under the `Never Cache the Following Pages` field).  Prior to this adjustment it would have been possible for that author's summary page to be cached too which would have been wrong. :octocat: 