### PR TITLE
WP-CLI - Prime the Page Cache

### DIFF
--- a/Cli.php
+++ b/Cli.php
@@ -33,8 +33,7 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 			$environment = Dispatcher::component( 'Root_Environment' );
 			$environment->fix_in_wpadmin( $config, true );
 		} catch ( Util_Environment_Exceptions $e ) {
-			\WP_CLI::error( __( 'Environment adjustment failed with error', 'w3-total-cache' ),
-				$e->getCombinedMessage() );
+			\WP_CLI::error( __( 'Environment adjustment failed with error:' . $e->getCombinedMessage(), 'w3-total-cache' ) );
 		}
 
 		\WP_CLI::success( __( 'Environment adjusted.', 'w3-total-cache' ) );
@@ -217,7 +216,6 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 
 		if ( empty( $name ) ) {
 			\WP_CLI::error( __( '<name> parameter is not specified', 'w3-total-cache' ) );
-			return;
 		}
 		if ( strpos( $name, '::' ) !== FALSE ) {
 			$name = explode('::', $name);
@@ -249,7 +247,6 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 				$v = json_encode( $c->get_array( $name ), JSON_PRETTY_PRINT );
 			else {
 				\WP_CLI::error( __( 'Unknown type ' . $type, 'w3-total-cache' ) );
-				return;
 			}
 
 			echo $v . "\n";
@@ -258,7 +255,6 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 
 			if ( count( $args ) <= 0 ) {
 				\WP_CLI::error( __( '<value> parameter is not specified', 'w3-total-cache' ) );
-				return;
 			}
 			$value = array_shift( $args );
 
@@ -269,7 +265,6 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 					$v = false;
 				else {
 					\WP_CLI::error( __( '<value> parameter ' . $value . ' is not boolean', 'w3-total-cache' ) );
-					return;
 				}
 			} elseif ( $type == 'integer' )
 				$v = (integer)$value;
@@ -280,7 +275,6 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 				$v = explode($delimiter, $value );
 			} else {
 				\WP_CLI::error( __( 'Unknown type ' . $type, 'w3-total-cache' ) );
-				return;
 			}
 
 			try {
@@ -305,9 +299,7 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 			$w3_querystring->browsercache_flush();
 		}
 		catch ( \Exception $e ) {
-			\WP_CLI::error( sprintf(
-					__( 'updating the query string failed. with error %s', 'w3-total-cache' ),
-					$e ) );
+			\WP_CLI::error( __( 'updating the query string failed. with error: ' . $e->getMessage(), 'w3-total-cache' ) );
 		}
 
 		\WP_CLI::success( __( 'The query string was updated successfully.', 'w3-total-cache' ) );
@@ -331,7 +323,7 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 			$w3_cdn_purge->cdn_purge_files( $purgeitems );
 		}
 		catch ( \Exception $e ) {
-			\WP_CLI::error( __( 'Files did not successfully purge with error %s', 'w3-total-cache' ), $e );
+			\WP_CLI::error( __( 'Files did not successfully purge with error: ' . $e->getMessage(), 'w3-total-cache' ) );
 		}
 		\WP_CLI::success( __( 'Files purged successfully.', 'w3-total-cache' ) );
 
@@ -367,14 +359,14 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 				);
 				$result = wp_remote_post( $url, $post );
 				if ( is_wp_error( $result ) ) {
-					\WP_CLI::error( __( 'Files did not successfully reload with error %s', 'w3-total-cache' ), $result );
+					\WP_CLI::error( __( 'Files did not successfully reload with error: ' . $result, 'w3-total-cache' ) );
 				} elseif ( $result['response']['code'] != '200' ) {
 					\WP_CLI::error( __( 'Files did not successfully reload with message: ', 'w3-total-cache' ) . $result['body'] );
 				}
 			}
 		}
 		catch ( \Exception $e ) {
-			\WP_CLI::error( __( 'Files did not successfully reload with error %s', 'w3-total-cache' ), $e );
+			\WP_CLI::error( __( 'Files did not successfully reload with error: ' . $e->getMessage(), 'w3-total-cache' ) );
 		}
 		\WP_CLI::success( __( 'Files reloaded successfully.', 'w3-total-cache' ) );
 
@@ -410,14 +402,14 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 				);
 				$result = wp_remote_post( $url, $post );
 				if ( is_wp_error( $result ) ) {
-					\WP_CLI::error( __( 'Files did not successfully delete with error %s', 'w3-total-cache' ), $result );
+					\WP_CLI::error( __( 'Files did not successfully delete with error ' . $result, 'w3-total-cache' ) );
 				} elseif ( $result['response']['code'] != '200' ) {
 					\WP_CLI::error( __( 'Files did not successfully delete with message: ', 'w3-total-cache' ). $result['body'] );
 				}
 			}
 		}
 		catch ( \Exception $e ) {
-			\WP_CLI::error( __( 'Files did not successfully delete with error %s', 'w3-total-cache' ), $e );
+			\WP_CLI::error( __( 'Files did not successfully delete with error: ' . $e->getMessage(), 'w3-total-cache' ) );
 		}
 		\WP_CLI::success( __( 'Files deleted successfully.', 'w3-total-cache' ) );
 
@@ -431,16 +423,104 @@ class W3TotalCache_Command extends \WP_CLI_Command {
 			$pgcache_cleanup = Dispatcher::component( 'PgCache_Plugin_Admin' );
 			$pgcache_cleanup->cleanup();
 		} catch ( \Exception $e ) {
-			\WP_CLI::error( __( 'PageCache Garbage cleanup did not start with error %s',
-					'w3-total-cache' ), $e );
+			\WP_CLI::error( __( 'PageCache Garbage cleanup did not start with error: ' . $e->getMessage(), 'w3-total-cache' ) );
 		}
 
-		\WP_CLI::success( __( 'PageCache Garbage cleanup triggered successfully.',
-				'w3-total-cache' ) );
+		\WP_CLI::success( __( 'PageCache Garbage cleanup triggered successfully.', 'w3-total-cache' ) );
 	}
+
+    /**
+     * Prime the page cache (cache preloader)
+     *
+     * ## OPTIONS
+     *
+     * [<stop>]
+     * : Stop the active page cache prime session.
+     *
+     * [--batch=<size>]
+     * : Max number of pages to create per batch. If not set, the value given in
+     * W3TC's Page Cache > Pages per Interval field is used. If size is 0 then
+     * all pages within the sitemap will be created/cached without the use of a
+     * batch and without waiting.
+     *
+     * [--interval=<seconds>]
+     * : Number of seconds to wait before creating another batch. If not set,
+     * the value given in W3TC's Page Cache > Update Interval field is used.
+     *
+     * [--sitemap=<url>]
+     * : The sitemap url specifying the pages to prime cache. If not set, the
+     * value given in W3TC's Page Cache > Sitemap URL field is used.
+     *
+     * ## EXAMPLES
+     *
+     *     # Prime the page cache using settings held within the W3TC config.
+     *     $ wp w3-total-cache prime
+     *
+     *     # Stop the currently active prime process.
+     *     $ wp w3-total-cache prime stop
+     *
+     *     # Prime the page cache (2 pages every 30 seconds).
+     *     $ wp w3-total-cache prime --batch=2 --interval=30
+     *
+     *     # Prime the page cache every 30 seconds using the given sitemap.
+     *     $ wp w3-total-cache prime --interval=30 --sitemap=http://site.com/sitemap.xml
+     */
+    function prime( $args = array() , $vars = array() ) {
+        try {
+            $action = array_shift( $args ) ;                
+            $w3_prime = Dispatcher::component( 'PgCache_Plugin_Admin' );
+
+            if ( $action == 'stop' ) {
+                if ( w3tc_wpcli_stop_prime( $result ) == false ) {
+                    \WP_CLI::warning( __( $result, 'w3-total-cache' ) );
+                } else {
+                    \WP_CLI::success( __( 'Page cache priming stopped.', 'w3-total-cache' ) );
+                }
+            } elseif ( strlen( $action ) > 0 ) {
+                $val = \WP_CLI::colorize( __( "%Y$action%n", 'w3-total-cache' ) );
+                \WP_CLI::error( __( "Unrecognized argument - $val.", 'w3-total-cache' ) );
+            } else {
+                $config = Dispatcher::config();
+                $user_limit = - 1;
+                $user_interval = - 1;
+                $user_sitemap = "";
+
+                if ( isset( $vars['interval'] ) && is_numeric( $vars['interval'] ) ) {
+                    $user_interval = intval( $vars['interval'] );
+                }
+
+                if ( isset( $vars['batch'] ) && is_numeric( $vars['batch'] ) ) {
+                    $user_limit = intval( $vars['batch'] );
+                }
+
+                if ( isset( $vars['sitemap'] ) && !empty( $vars['sitemap'] ) ) {
+                    $user_sitemap = trim( $vars['sitemap'] );
+                }
+
+                $limit = $user_limit == - 1 ? $config->get_integer( 'pgcache.prime.limit' ) : $user_limit;
+                $interval = $user_interval == - 1 ? $config->get_integer( 'pgcache.prime.interval' ) : $user_interval;
+                $sitemap = empty( $user_sitemap ) ? $config->get_string( 'pgcache.prime.sitemap' ) : $user_sitemap;
+                
+                if ( empty( $sitemap ) ) {
+                    \WP_CLI::error( __( "Prime page cache halted - Unable to load sitemap. A sitemap is needed to prime the page cache.", 'w3-total-cache' ) );
+                } elseif ( ( $res = $w3_prime->prime_cli( $limit, $interval, $sitemap, 0, true ) ) === false ) {
+                    \WP_CLI::warning( __( 'Page cache priming is already active.', 'w3-total-cache' ) );
+                } else {
+                    /**
+                     * Use inter-process messaging, if available, to help manage the prime
+                     */                
+                    if ( extension_loaded( 'sysvmsg' ) ) {
+                        msg_send( msg_get_queue( 99909 ) , 99, "prime_started" );
+                    }
+
+                    \WP_CLI::success( __( "Page cache priming started $res.", 'w3-total-cache' ) );
+                }
+            }
+        } catch( \Exception $e ) {
+            \WP_CLI::error( __( 'Error: ' . $e->getMessage(), 'w3-total-cache' ) );
+        }
+    }        
 }
-
-
 
 if ( method_exists( '\WP_CLI', 'add_command' ) ) {
 	\WP_CLI::add_command( 'w3-total-cache', '\W3TC\W3TotalCache_Command' );

--- a/PgCache_Plugin.php
+++ b/PgCache_Plugin.php
@@ -58,6 +58,8 @@ class PgCache_Plugin {
 		}
 
 		add_action( 'w3_pgcache_prime', array( $this, 'prime' ) );
+        
+        add_action( 'w3_pgcache_prime_cli', array( $this, 'prime_cli' ), 10, 4 );
 
 		Util_AttachToActions::flush_posts_on_actions();
 
@@ -114,6 +116,20 @@ class PgCache_Plugin {
 	function prime( $start = 0 ) {
 		$this->_get_admin()->prime( $start );
 	}
+
+    /**
+     * Prime cache (WP_CLI)
+     *
+     * @param   integer $user_limit     Pages per batch size
+     * @param   integer $user_interval  Number of seconds to wait before creating another batch
+     * @param   string  $user_sitemap   The sitemap url to use
+     * @param   integer $start          Index position within the sitemap to prime cache
+     * @param   boolean $boot           Indicates if the prime cache is about to start for the first time
+     * @return  void
+     */
+    function prime_cli( $user_limit, $user_interval, $user_sitemap, $start, $boot = false ) {
+        $this->_get_admin()->prime_cli( $user_limit, $user_interval, $user_sitemap, $start, $boot );
+    }
 
 	/**
 	 * Instantiates worker on demand

--- a/Root_Loader.php
+++ b/Root_Loader.php
@@ -115,6 +115,7 @@ class Root_Loader {
 	 * Deactivation action hook
 	 */
 	public function deactivate() {
+		w3tc_wpcli_stop_prime(); // Stop the WP-CLI page cache prime if it's still running
 		Root_AdminActivation::deactivate();
 	}
 

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -142,7 +142,7 @@ Util_Ui::config_item( array(
 					<input id="pgcache_prime_limit" type="text" name="pgcache__prime__limit"
 						<?php Util_Ui::sealing_disabled( 'pgcache.' ) ?>
 						value="<?php echo esc_attr( $this->_config->get_integer( 'pgcache.prime.limit' ) ); ?>" size="8" /><br />
-					<span class="description"><?php _e( 'Limit the number of pages to create per batch. Fewer pages may be better for under-powered servers.', 'w3-total-cache' ); ?></span>
+                    <span class="description"><?php _e( 'Limit the number of pages to create per batch. Fewer pages may be better for under-powered servers. Set to 0 for no limit.', 'w3-total-cache' ); ?></span>
 				</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
This adds the much desired cache preload feature to W3 Total Cache's [WP-CLI](http://wp-cli.org/) space.  It's the ability to prime the page cache from the command line.  It was a feature request by WP forum users to ease the burden of script-managed re-caching of multiple sites remotely.  It was also added to help flesh out W3 Total Cache's completeness when using WP-CLI.

Because the priming can potentially take very long to process it has been designed to run asynchronously in the background after initiating the request, thus, freeing up the command line prompt immediately.  There is also a command to stop the running prime process, if needed.

This also fixes a few minor bugs in _Cli.php_:  The `Exception` object was being incorrectly passed to the `WP_CLI::Error()` function in some areas, ironically, causing an exception error of its own.  It seems the `sprintf()` wrapper was missing in a few spots and the object's `getMessage()` call was also missing.  To save on an extra function call i just opted to concatenate the exception message string into their proper positions.

## Important Coding Note

Since user's batch sizes can potentially be large enough that the time to process each batch can lead to another scheduled batch running while the previous one is not finished,  this prime process keeps track of the active process IDs (each batch has its own process ID) so that if the user decides to stop the priming it can do so by terminating all active batch processes (e.g. via the _"stop_" CLI command or if they deactivate the plugin).  To accomplish this it keeps track by writing a list of these active process IDs to disk or using an interprocess messaging system, depending on what is made available in the environment (**posix** or **sysvmsg** or **exec**).

It was determined that WP's database functions (and therefore, W3TC's new _State_ class) was not suitable because since each batch process would need to write out their ID, the available db functions actually cached the response for that specific process ID and so when a different process ID updated the db entry, the original process ID would not be made aware of it -- it would just get served an old, outdated cached version.  And so using direct file read/write or interprocess messaging was more efficient in this case to make sure all active processes were communicating correctly with the latest data when priming.

As a result, special **`w3tc_lock_read()`** **`w3tc_lock_write()`** functions were created to handle the proper reading/writing of files, accessed by mutli-processes, to disk (if using posix or exec).  Note the use of **`clearstatcache()`** to prevent serving back cached versions of the file which is critical when multi-processes are being managed.

## How the WP-CLI Prime Cache Works 
### Format:

```r
wp w3-total-cache prime [stop] [--batch=<size>] [--interval=<seconds>] [--sitemap=<url>]
```

Because all the arguments are optional, if the arg is not present it will default to its corresponding user-set configuration value as seen in Page Cache's **Cache Preload** section.

### Usage Examples:
- _Begin priming the page cache using the already defined interval, batch size, and sitemap url values as shown under W3TC's **Performance > Page Cache > Cache Preload** section:_
  
  ```r
  wp w3-total-cache prime
  ```
- _If the page cache is currently being primed this will end that process:_
  
  ```r
  wp w3-total-cache prime stop
  ```
- _Begin priming the page cache at the rate of 2 pages every 30 seconds using the sitemap url held within W3TC's **Performance > Page Cache > Cache Preload > Sitemap URL** box:_
  
  ```r
  wp w3-total-cache prime --batch=2 --interval=30
  ```
- _Using the provided sitemap url, its pages are primed in batch sizes (as defined by W3TC's **Performance > Page Cache > Cache Preload > Pages per Interval** box) every 30 seconds until all pages within the given sitemap is complete:_
  
  ```r
  wp w3-total-cache prime --interval=30 --sitemap=http://domain.com/sitemap.xml
  ```
:octocat: 