### PR TITLE
Flushing Not Working Consistently For Post Changes

### DIFF
--- a/Util_AttachToActions.php
+++ b/Util_AttachToActions.php
@@ -15,6 +15,56 @@ class Util_AttachToActions {
 
 		$o = new Util_AttachToActions();
 
+		add_action( 'publish_phone', array(
+				$o,
+				'on_change'
+			), 0 );
+
+		add_action( 'wp_trash_post', array(
+				$o,
+				'on_post_change'
+			), 0 );
+
+		add_action( 'save_post', array(
+				$o,
+				'on_post_change'
+			), 0 );
+
+		add_action( 'comment_post', array(
+				$o,
+				'on_comment_change'
+			), 0 );
+
+		add_action( 'edit_comment', array(
+				$o,
+				'on_comment_change'
+			), 0 );
+
+		add_action( 'delete_comment', array(
+				$o,
+				'on_comment_change'
+			), 0 );
+
+		add_action( 'wp_set_comment_status', array(
+				$o,
+				'on_comment_status'
+			), 0, 2 );
+
+		add_action( 'trackback_post', array(
+				$o,
+				'on_comment_change'
+			), 0 );
+
+		add_action( 'pingback_post', array(
+				$o,
+				'on_comment_change'
+			), 0 );
+
+		add_action( 'delete_post', array(
+				$o,
+				'on_post_change'
+			), 0 );
+
 		add_action( 'clean_post_cache', array(
 				$o,
 				'on_post_change'
@@ -90,4 +140,36 @@ class Util_AttachToActions {
 		$cacheFlush = Dispatcher::component( 'CacheFlush' );
 		$cacheFlush->flush_posts();
 	}
+
+
+
+	/**
+	 * Comment change action
+	 *
+	 * @param integer $comment_id
+	 */
+	function on_comment_change( $comment_id ) {
+		$post_id = 0;
+
+		if ( $comment_id ) {
+			$comment = get_comment( $comment_id, ARRAY_A );
+			$post_id = !empty( $comment['comment_post_ID'] ) ? (int) $comment['comment_post_ID'] : 0;
+		}
+
+		$this->on_post_change( $post_id );
+	}
+
+
+
+	/**
+	 * Comment status action
+	 *
+	 * @param integer $comment_id
+	 * @param string  $status
+	 */
+	function on_comment_status( $comment_id, $status ) {
+		if ( $status === 'approve' || $status === '1' ) {
+			$this->on_comment_change( $comment_id );
+		}
+	}	
 }

--- a/Util_PageUrls.php
+++ b/Util_PageUrls.php
@@ -91,12 +91,21 @@ class Util_PageUrls {
 
 		if ( !isset( $post_urls[$post_id] ) ) {
 			$full_urls = array();
-			$post_link = get_permalink( $post_id );
+			$post = get_post( $post_id );
+			
+			// On the admin page when changing a post type to "Draft" or "Pending Review"
+			// the get_permalink() returns back in the form: http://foo.bar/?p=###
+			// even if the site's permalink setting is different (e.g. http://foo.bar/post-name/).
+			// When this happens the post can potentially not get flushed.
+			// Setting the "post_status" to empty forces get_permalink() to return 
+			// the correct url for flushing.
+			
+			$post->post_status = "";
+			$post_link = get_permalink( $post );
 			$post_uri = str_replace( Util_Environment::home_domain_root_url(), '', $post_link );
 
 			$full_urls[] = $post_link;
 			$uris[] = $post_uri;
-			$post = get_post( $post_id );
 			$matches =array();
 			if ( $post && ( $post_pages_number = preg_match_all( '/\<\!\-\-nextpage\-\-\>/', $post->post_content, $matches ) )>0 ) {
 				global $wp_rewrite;


### PR DESCRIPTION
It was discovered that while logged in and performing an action such as deleting a post or changing it to draft status, that the post does not flush despite the purge policy settings.

## Why the Problem Occurs

There are two underlying causes:

1. Several WP actions such as `delete_post` and `save_post` (among many others) appear to be missing.  These actions are necessary for W3TC to trigger a flush when a post changes.  Although they were previously used in the v0.9.4.x generation, most appear to be left out (by accident?) for v0.9.5.x.  As such, these missing actions were added and, in the process, fixed several problems.

2. In regards to draft and pending review though, when a post is switched from _Published_ to _Draft_ (or _Pending Review_) W3TC is unable to handle flushing because the returned URL from `get_permalink()`, as used in W3TC's `get_post_urls()` function, is in plain form (i.e., http://foo.bar/?p=###) instead of being in the normal one that uses the site's permalink setting (e.g., http://foo.bar/post-name/).  This seems to only occur when dealing with draft or pending review status.  It also appears to be an old bug that spans all versions of W3TC.  The solution to this involves making the `post_status` variable (of the `$post` object) empty and passing `$post` to `get_permalink()` instead of the post id.  Doing it this way triggers the correct URL to be returned (a URL that uses the site's permalink setting).  And with that, flushing begins to work when switching a published post to draft (or pending review).

:octocat: 