### PR TITLE
Amazon Web Services (AWS) Signature v4 Support And New Locations

### DIFF
--- a/CdnEngine_S3.php
+++ b/CdnEngine_S3.php
@@ -30,6 +30,7 @@ class CdnEngine_S3 extends CdnEngine_Base {
 				'key' => '',
 				'secret' => '',
 				'bucket' => '',
+                'bucket_location' => '',
 				'cname' => array(),
 			), $config );
 
@@ -83,7 +84,19 @@ class CdnEngine_S3 extends CdnEngine_Base {
 			return false;
 		}
 
-		$this->_s3 = new \S3( $this->_config['key'], $this->_config['secret'], false );
+        if ( empty( $this->_config['bucket_location'] ) ) {
+            $region = '';
+            $endpoint = 's3.amazonaws.com';
+        } else {
+            $region = $this->_config['bucket_location'];
+            $endpoint = 's3.dualstack.'.$region.'.amazonaws.com';
+        }
+
+        $this->_s3 = new \S3( $this->_config['key'], $this->_config['secret'], false, $endpoint, $region );
+
+        if ( empty( $region ) ) {
+            $this->_s3->setSignatureVersion( 'v2' );
+        }
 
 		return true;
 	}
@@ -167,10 +180,15 @@ class CdnEngine_S3 extends CdnEngine_Base {
 				W3TC_CDN_RESULT_OK, 'OK', $file );
 		}
 
+        if ( strpos( $this->_get_last_error(), 'AWS4-HMAC-SHA256' ) !== false ) {
+            $error = "Bucket location region is incorrect. Please select the right one.";
+        } else {
+            $error = sprintf( 'Unable to put object (%s).', $this->_get_last_error() );
+        }
+
 		return $this->_get_result( $local_path, $remote_path,
 			W3TC_CDN_RESULT_ERROR,
-			sprintf( 'Unable to put object (%s).', $this->_get_last_error() ),
-			$file );
+			$error );
 	}
 
 	/**
@@ -235,10 +253,15 @@ class CdnEngine_S3 extends CdnEngine_Base {
 				W3TC_CDN_RESULT_OK, 'OK', $file );
 		}
 
+        if ( strpos( $this->_get_last_error(), 'AWS4-HMAC-SHA256' ) !== false ) {
+            $error = "Bucket location region is incorrect. Please select the right one.";
+        } else {
+            $error = sprintf( 'Unable to put object (%s).', $this->_get_last_error() );
+        }
+
 		return $this->_get_result( $local_path, $remote_path,
 			W3TC_CDN_RESULT_ERROR,
-			sprintf( 'Unable to put object (%s).', $this->_get_last_error() ),
-			$file );
+			$error );
 	}
 
 	/**
@@ -337,7 +360,11 @@ class CdnEngine_S3 extends CdnEngine_Base {
 		}
 
 		if ( !@$this->_s3->putObjectString( $string, $this->_config['bucket'], $string, \S3::ACL_PUBLIC_READ ) ) {
-			$error = sprintf( 'Unable to put object (%s).', $this->_get_last_error() );
+            if ( strpos( $this->_get_last_error(), 'AWS4-HMAC-SHA256' ) !== false ) {
+            	$error = "Bucket location region is incorrect. Please select the right one.";
+            } else {
+            	$error = sprintf( 'Unable to put object (%s).', $this->_get_last_error() );
+            }
 
 			$this->_restore_error_handler();
 

--- a/CdnEngine_S3_Cf.php
+++ b/CdnEngine_S3_Cf.php
@@ -67,7 +67,19 @@ class CdnEngine_S3_Cf extends CdnEngine_S3 {
 			return false;
 		}
 
-		$this->_s3 = new \S3( $this->_config['key'], $this->_config['secret'], false );
+        if ( empty( $this->_config['bucket_location'] ) ) {
+            $region = '';
+            $endpoint = 's3.amazonaws.com';
+        } else {
+            $region = $this->_config['bucket_location'];
+            $endpoint = 's3.dualstack.'.$region.'.amazonaws.com';
+        }
+
+        $this->_s3 = new \S3( $this->_config['key'], $this->_config['secret'], false, $endpoint, $region );
+
+        if ( empty( $region ) ) {
+        	$this->_s3->setSignatureVersion( 'v2' );
+        }
 
 		return true;
 	}
@@ -193,7 +205,7 @@ class CdnEngine_S3_Cf extends CdnEngine_S3 {
 		}
 
 		$this->_set_error_handler();
-		$invalidation = @$this->_s3->createInvalidation( $dist['id'], $paths );
+		$invalidation = @$this->_s3->invalidateDistribution( $dist['id'], $paths );
 		$this->_restore_error_handler();
 
 		if ( !$invalidation ) {
@@ -358,7 +370,7 @@ class CdnEngine_S3_Cf extends CdnEngine_S3 {
 
 		$matches = null;
 
-		if ( preg_match( '~^(.+)\.cloudfront\.net$~', $dist['domain'], $matches ) ) {
+		if ( !empty( $dist['domain'] ) && preg_match( '~^(.+)\.cloudfront\.net$~', $dist['domain'], $matches ) ) {
 			$container_id = $matches[1];
 		}
 

--- a/CdnEngine_S3_Compatible.php
+++ b/CdnEngine_S3_Compatible.php
@@ -33,6 +33,9 @@ class CdnEngine_S3_Compatible extends CdnEngine_Base {
 
 		$this->_s3 = new \S3( $config['key'], $config['secret'], false,
 			$config['api_host'] );
+
+        $this->_s3->setSignatureVersion( 'v2' );
+
 		parent::__construct( $config );
 	}
 

--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -492,12 +492,22 @@ class Cdn_AdminActions {
 	function w3tc_cdn_s3_bucket_location() {
 		$type = Util_Request::get_string( 'type', 's3' );
 
-		$locations = array(
-			'' => 'US (Default)',
-			'us-west-1' => __( 'US-West (Northern California)', 'w3-total-cache' ),
-			'EU' => 'Europe',
-			'ap-southeast-1' => __( 'AP-SouthEast (Singapore)', 'w3-total-cache' ),
-		);
+        $locations = array(
+            'us-east-1' 	=> __( 'US East (N. Virginia)', 'w3-total-cache' ),
+            'us-east-2' 	=> __( 'US East (Ohio)', 'w3-total-cache' ),
+            'us-west-1' 	=> __( 'US-West (N. California)', 'w3-total-cache' ),
+            'us-west-2' 	=> __( 'US-West (Oregon)', 'w3-total-cache' ),
+            'ca-central-1'	=> __( 'Canada (Central)', 'w3-total-cache' ),
+            'ap-south-1' 	=> __( 'Asia Pacific (Mumbai)', 'w3-total-cache' ),
+            'ap-northeast-2'=> __( 'Asia Pacific (Seoul)', 'w3-total-cache' ),
+            'ap-southeast-1'=> __( 'Asia Pacific (Singapore)', 'w3-total-cache' ),
+            'ap-southeast-2'=> __( 'Asia Pacific (Sydney)', 'w3-total-cache' ),
+            'ap-northeast-1'=> __( 'Asia Pacific (Tokyo)', 'w3-total-cache' ),
+            'eu-central-1' 	=> __( 'EU (Frankfurt)', 'w3-total-cache' ),
+            'eu-west-1' 	=> __( 'EU (Ireland)', 'w3-total-cache' ),
+            'eu-west-2' 	=> __( 'EU (London)', 'w3-total-cache' ),
+            'sa-east-1' 	=> __( 'South America (S&atilde;o Paulo)', 'w3-total-cache' ),
+        );
 
 		include W3TC_INC_DIR . '/lightbox/cdn_s3_bucket_location.php';
 	}

--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -497,7 +497,7 @@ class Cdn_AdminActions {
             'us-east-2' 	=> __( 'US East (Ohio)', 'w3-total-cache' ),
             'us-west-1' 	=> __( 'US-West (N. California)', 'w3-total-cache' ),
             'us-west-2' 	=> __( 'US-West (Oregon)', 'w3-total-cache' ),
-            'ca-central-1'	=> __( 'Canada (Central)', 'w3-total-cache' ),
+            'ca-central-1'	=> __( 'Canada (Montreal)', 'w3-total-cache' ),
             'ap-south-1' 	=> __( 'Asia Pacific (Mumbai)', 'w3-total-cache' ),
             'ap-northeast-2'=> __( 'Asia Pacific (Seoul)', 'w3-total-cache' ),
             'ap-southeast-1'=> __( 'Asia Pacific (Singapore)', 'w3-total-cache' ),

--- a/Cdn_Core.php
+++ b/Cdn_Core.php
@@ -367,6 +367,7 @@ class Cdn_Core {
 					'key' => $this->_config->get_string( 'cdn.cf.key' ),
 					'secret' => $this->_config->get_string( 'cdn.cf.secret' ),
 					'bucket' => $this->_config->get_string( 'cdn.cf.bucket' ),
+					'bucket_location' => $this->_config->get_string( 'cdn.cf.bucket.location' ),
 					'id' => $this->_config->get_string( 'cdn.cf.id' ),
 					'cname' => $this->_config->get_array( 'cdn.cf.cname' ),
 					'ssl' => $this->_config->get_string( 'cdn.cf.ssl' ),
@@ -533,6 +534,7 @@ class Cdn_Core {
 					'key' => $this->_config->get_string( 'cdn.s3.key' ),
 					'secret' => $this->_config->get_string( 'cdn.s3.secret' ),
 					'bucket' => $this->_config->get_string( 'cdn.s3.bucket' ),
+					'bucket_location' => $this->_config->get_string( 'cdn.s3.bucket.location' ),
 					'cname' => $this->_config->get_array( 'cdn.s3.cname' ),
 					'ssl' => $this->_config->get_string( 'cdn.s3.ssl' ),
 					'compression' => $compression

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -1103,6 +1103,10 @@ $keys = array(
 		'type' => 'string',
 		'default' => ''
 	),
+    'cdn.s3.bucket.location' => array(
+        'type' => 'string',
+        'default' => 'us-east-1'
+    ),
 	'cdn.s3.cname' => array(
 		'type' => 'array',
 		'default' => array()
@@ -1129,6 +1133,10 @@ $keys = array(
 		'type' => 'string',
 		'default' => ''
 	),
+    'cdn.cf.bucket.location' => array(
+        'type' => 'string',
+        'default' => 'us-east-1'
+    ),
 	'cdn.cf.id' => array(
 		'type' => 'string',
 		'default' => ''

--- a/inc/options/cdn/cf.php
+++ b/inc/options/cdn/cf.php
@@ -28,26 +28,26 @@ if ( !defined( 'W3TC' ) )
 	<th><label for="cdn_cf_bucket"><?php _e( 'Bucket:', 'w3-total-cache' ); ?></label></th>
     <td>
         <input id="cdn_cf_bucket" type="text" name="cdn__cf__bucket"
-        <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cf.bucket' ) ); ?>" size="30" />
+        <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( strtolower( $this->_config->get_string( 'cdn.cf.bucket' ) ) ); ?>" size="30" />
         <select id="cdn_cf_bucket_location" name="cdn__cf__bucket__location" style="margin-top:-4px">
             <option value="" style="display:none;">Select Bucket Location</option>
-            <option value="us-east-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-east-1'); ?>>US East (N. Virginia)</option>
-            <option value="us-east-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-east-2'); ?>>US East (Ohio)</option>
-            <option value="us-west-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-west-1'); ?>>US-West (N. California)</option>
-            <option value="us-west-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-west-2'); ?>>US-West (Oregon)</option>
-            <option value="ca-central-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ca-central-1'); ?>>Canada (Central)</option>
-            <option value="ap-south-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-south-1'); ?>>Asia Pacific (Mumbai)</option>
-            <option value="ap-northeast-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-northeast-2'); ?>>Asia Pacific (Seoul)</option>
-            <option value="ap-southeast-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-southeast-1'); ?>>Asia Pacific (Singapore)</option>
-            <option value="ap-southeast-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-southeast-2'); ?>>Asia Pacific (Sydney)</option>
-            <option value="ap-northeast-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-northeast-1'); ?>>Asia Pacific (Tokyo)</option>
-            <option value="eu-central-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'eu-central-1'); ?>>EU (Frankfurt)</option>
-            <option value="eu-west-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'eu-west-1'); ?>>EU (Ireland)</option>
-            <option value="eu-west-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'eu-west-2'); ?>>EU (London)</option>
-            <option value="sa-east-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'sa-east-1'); ?>>South America (S&atilde;o Paulo)</option>
+            <option value="us-east-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'us-east-1' ); ?>>US East (N. Virginia)</option>
+            <option value="us-east-2"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'us-east-2' ); ?>>US East (Ohio)</option>
+            <option value="us-west-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'us-west-1' ); ?>>US-West (N. California)</option>
+            <option value="us-west-2"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'us-west-2' ); ?>>US-West (Oregon)</option>
+            <option value="ca-central-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'ca-central-1' ); ?>>Canada (Montreal)</option>
+            <option value="ap-south-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'ap-south-1' ); ?>>Asia Pacific (Mumbai)</option>
+            <option value="ap-northeast-2"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'ap-northeast-2' ); ?>>Asia Pacific (Seoul)</option>
+            <option value="ap-southeast-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'ap-southeast-1' ); ?>>Asia Pacific (Singapore)</option>
+            <option value="ap-southeast-2"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'ap-southeast-2' ); ?>>Asia Pacific (Sydney)</option>
+            <option value="ap-northeast-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'ap-northeast-1' ); ?>>Asia Pacific (Tokyo)</option>
+            <option value="eu-central-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'eu-central-1' ); ?>>EU (Frankfurt)</option>
+            <option value="eu-west-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'eu-west-1' ); ?>>EU (Ireland)</option>
+            <option value="eu-west-2"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'eu-west-2' ); ?>>EU (London)</option>
+            <option value="sa-east-1"<?php selected( $this->_config->get_string( 'cdn.cf.bucket.location' ), 'sa-east-1' ); ?>>South America (S&atilde;o Paulo)</option>
         </select>
         <b>or</b>
-        <input id="cdn_create_container" class="button {type: 'cf', nonce: '<?php echo wp_create_nonce('w3tc'); ?>'}" type="button" value="<?php _e('Create as new bucket with distribution', 'w3-total-cache'); ?>" /> <span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>
+        <input id="cdn_create_container" class="button {type: 'cf', nonce: '<?php echo wp_create_nonce( 'w3tc' ); ?>'}" type="button" value="<?php _e( 'Create as new bucket with distribution', 'w3-total-cache' ); ?>" /> <span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>
     </td>
 </tr>
 <tr>

--- a/inc/options/cdn/cf.php
+++ b/inc/options/cdn/cf.php
@@ -26,12 +26,29 @@ if ( !defined( 'W3TC' ) )
 </tr>
 <tr>
 	<th><label for="cdn_cf_bucket"><?php _e( 'Bucket:', 'w3-total-cache' ); ?></label></th>
-	<td>
-		<input id="cdn_cf_bucket" type="text" name="cdn__cf__bucket"
-                       <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cf.bucket' ) ); ?>" size="30" />
-		<input class="button button-cdn-cf-bucket-location cdn_cf {nonce: '<?php echo wp_create_nonce( 'w3tc' ); ?>'}"
-                       <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> type="button" value="<?php _e( 'Create bucket &amp; distribution', 'w3-total-cache' ); ?>" />
-	</td>
+    <td>
+        <input id="cdn_cf_bucket" type="text" name="cdn__cf__bucket"
+        <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( $this->_config->get_string( 'cdn.cf.bucket' ) ); ?>" size="30" />
+        <select id="cdn_cf_bucket_location" name="cdn__cf__bucket__location" style="margin-top:-4px">
+            <option value="" style="display:none;">Select Bucket Location</option>
+            <option value="us-east-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-east-1'); ?>>US East (N. Virginia)</option>
+            <option value="us-east-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-east-2'); ?>>US East (Ohio)</option>
+            <option value="us-west-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-west-1'); ?>>US-West (N. California)</option>
+            <option value="us-west-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'us-west-2'); ?>>US-West (Oregon)</option>
+            <option value="ca-central-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ca-central-1'); ?>>Canada (Central)</option>
+            <option value="ap-south-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-south-1'); ?>>Asia Pacific (Mumbai)</option>
+            <option value="ap-northeast-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-northeast-2'); ?>>Asia Pacific (Seoul)</option>
+            <option value="ap-southeast-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-southeast-1'); ?>>Asia Pacific (Singapore)</option>
+            <option value="ap-southeast-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-southeast-2'); ?>>Asia Pacific (Sydney)</option>
+            <option value="ap-northeast-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'ap-northeast-1'); ?>>Asia Pacific (Tokyo)</option>
+            <option value="eu-central-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'eu-central-1'); ?>>EU (Frankfurt)</option>
+            <option value="eu-west-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'eu-west-1'); ?>>EU (Ireland)</option>
+            <option value="eu-west-2"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'eu-west-2'); ?>>EU (London)</option>
+            <option value="sa-east-1"<?php selected($this->_config->get_string('cdn.cf.bucket.location'), 'sa-east-1'); ?>>South America (S&atilde;o Paulo)</option>
+        </select>
+        <b>or</b>
+        <input id="cdn_create_container" class="button {type: 'cf', nonce: '<?php echo wp_create_nonce('w3tc'); ?>'}" type="button" value="<?php _e('Create as new bucket with distribution', 'w3-total-cache'); ?>" /> <span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>
+    </td>
 </tr>
 <tr>
 	<th><label for="cdn_cf_ssl"><?php _e( '<acronym title="Secure Sockets Layer">SSL</acronym> support:', 'w3-total-cache' ); ?></label></th>

--- a/inc/options/cdn/s3.php
+++ b/inc/options/cdn/s3.php
@@ -26,29 +26,28 @@ if ( !defined( 'W3TC' ) )
 </tr>
 <tr>
 	<th><label for="cdn_s3_bucket"><?php _e( 'Bucket:', 'w3-total-cache' ); ?></label></th>
-	
     <td>
         <input id="cdn_s3_bucket" type="text" name="cdn__s3__bucket"
-        <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( $this->_config->get_string( 'cdn.s3.bucket' ) ); ?>" size="30" />
+        <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( strtolower( $this->_config->get_string( 'cdn.s3.bucket' ) ) ); ?>" size="30" />
         <select id="cdn_s3_bucket_location" name="cdn__s3__bucket__location" style="margin-top:-4px">
             <option value="" style="display:none;">Select Bucket Location</option>
-            <option value="us-east-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-east-1'); ?>>US East (N. Virginia)</option>
-            <option value="us-east-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-east-2'); ?>>US East (Ohio)</option>
-            <option value="us-west-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-west-1'); ?>>US-West (N. California)</option>
-            <option value="us-west-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-west-2'); ?>>US-West (Oregon)</option>
-            <option value="ca-central-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ca-central-1'); ?>>Canada (Central)</option>
-            <option value="ap-south-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-south-1'); ?>>Asia Pacific (Mumbai)</option>
-            <option value="ap-northeast-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-northeast-2'); ?>>Asia Pacific (Seoul)</option>
-            <option value="ap-southeast-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-southeast-1'); ?>>Asia Pacific (Singapore)</option>
-            <option value="ap-southeast-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-southeast-2'); ?>>Asia Pacific (Sydney)</option>
-            <option value="ap-northeast-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-northeast-1'); ?>>Asia Pacific (Tokyo)</option>
-            <option value="eu-central-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'eu-central-1'); ?>>EU (Frankfurt)</option>
-            <option value="eu-west-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'eu-west-1'); ?>>EU (Ireland)</option>
-            <option value="eu-west-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'eu-west-2'); ?>>EU (London)</option>
-            <option value="sa-east-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'sa-east-1'); ?>>South America (S&atilde;o Paulo)</option>
+            <option value="us-east-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'us-east-1' ); ?>>US East (N. Virginia)</option>
+            <option value="us-east-2"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'us-east-2' ); ?>>US East (Ohio)</option>
+            <option value="us-west-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'us-west-1' ); ?>>US-West (N. California)</option>
+            <option value="us-west-2"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'us-west-2' ); ?>>US-West (Oregon)</option>
+            <option value="ca-central-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'ca-central-1' ); ?>>Canada (Montreal)</option>
+            <option value="ap-south-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'ap-south-1' ); ?>>Asia Pacific (Mumbai)</option>
+            <option value="ap-northeast-2"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'ap-northeast-2' ); ?>>Asia Pacific (Seoul)</option>
+            <option value="ap-southeast-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'ap-southeast-1' ); ?>>Asia Pacific (Singapore)</option>
+            <option value="ap-southeast-2"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'ap-southeast-2' ); ?>>Asia Pacific (Sydney)</option>
+            <option value="ap-northeast-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'ap-northeast-1' ); ?>>Asia Pacific (Tokyo)</option>
+            <option value="eu-central-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'eu-central-1' ); ?>>EU (Frankfurt)</option>
+            <option value="eu-west-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'eu-west-1' ); ?>>EU (Ireland)</option>
+            <option value="eu-west-2"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'eu-west-2' ); ?>>EU (London)</option>
+            <option value="sa-east-1"<?php selected( $this->_config->get_string( 'cdn.s3.bucket.location' ), 'sa-east-1' ); ?>>South America (S&atilde;o Paulo)</option>
         </select>
         <b>or</b>
-        <input id="cdn_create_container" class="button {type: 's3', nonce: '<?php echo wp_create_nonce('w3tc'); ?>'}" type="button" value="<?php _e('Create as new bucket', 'w3-total-cache'); ?>" /> <span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>
+        <input id="cdn_create_container" class="button {type: 's3', nonce: '<?php echo wp_create_nonce( 'w3tc' ); ?>'}" type="button" value="<?php _e( 'Create as new bucket', 'w3-total-cache' ); ?>" /> <span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>
     </td>
 </tr>
 <tr>

--- a/inc/options/cdn/s3.php
+++ b/inc/options/cdn/s3.php
@@ -26,11 +26,30 @@ if ( !defined( 'W3TC' ) )
 </tr>
 <tr>
 	<th><label for="cdn_s3_bucket"><?php _e( 'Bucket:', 'w3-total-cache' ); ?></label></th>
-	<td>
-		<input id="cdn_s3_bucket" type="text" name="cdn__s3__bucket"
-                   <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( $this->_config->get_string( 'cdn.s3.bucket' ) ); ?>" size="30" />
-		<input class="button button-cdn-s3-bucket-location cdn_s3 {nonce: '<?php echo wp_create_nonce( 'w3tc' ); ?>'}" type="button" value="<?php _e( 'Create bucket', 'w3-total-cache' ); ?>" />
-	</td>
+	
+    <td>
+        <input id="cdn_s3_bucket" type="text" name="cdn__s3__bucket"
+        <?php Util_Ui::sealing_disabled( 'cdn.' ) ?> value="<?php echo esc_attr( $this->_config->get_string( 'cdn.s3.bucket' ) ); ?>" size="30" />
+        <select id="cdn_s3_bucket_location" name="cdn__s3__bucket__location" style="margin-top:-4px">
+            <option value="" style="display:none;">Select Bucket Location</option>
+            <option value="us-east-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-east-1'); ?>>US East (N. Virginia)</option>
+            <option value="us-east-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-east-2'); ?>>US East (Ohio)</option>
+            <option value="us-west-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-west-1'); ?>>US-West (N. California)</option>
+            <option value="us-west-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'us-west-2'); ?>>US-West (Oregon)</option>
+            <option value="ca-central-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ca-central-1'); ?>>Canada (Central)</option>
+            <option value="ap-south-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-south-1'); ?>>Asia Pacific (Mumbai)</option>
+            <option value="ap-northeast-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-northeast-2'); ?>>Asia Pacific (Seoul)</option>
+            <option value="ap-southeast-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-southeast-1'); ?>>Asia Pacific (Singapore)</option>
+            <option value="ap-southeast-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-southeast-2'); ?>>Asia Pacific (Sydney)</option>
+            <option value="ap-northeast-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'ap-northeast-1'); ?>>Asia Pacific (Tokyo)</option>
+            <option value="eu-central-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'eu-central-1'); ?>>EU (Frankfurt)</option>
+            <option value="eu-west-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'eu-west-1'); ?>>EU (Ireland)</option>
+            <option value="eu-west-2"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'eu-west-2'); ?>>EU (London)</option>
+            <option value="sa-east-1"<?php selected($this->_config->get_string('cdn.s3.bucket.location'), 'sa-east-1'); ?>>South America (S&atilde;o Paulo)</option>
+        </select>
+        <b>or</b>
+        <input id="cdn_create_container" class="button {type: 's3', nonce: '<?php echo wp_create_nonce('w3tc'); ?>'}" type="button" value="<?php _e('Create as new bucket', 'w3-total-cache'); ?>" /> <span id="cdn_create_container_status" class="w3tc-status w3tc-process"></span>
+    </td>
 </tr>
 <tr>
 	<th><label for="cdn_s3_ssl"><?php _e( '<acronym title="Secure Sockets Layer">SSL</acronym> support:', 'w3-total-cache' ); ?></label></th>

--- a/lib/S3.php
+++ b/lib/S3.php
@@ -2193,7 +2193,7 @@ final class S3Request
 		
 		$this->endpoint = $endpoint;
 		$this->verb = $verb;
-		$this->bucket = strtolower($bucket);
+		$this->bucket = $bucket;
 		$this->uri = $uri !== '' ? '/'.str_replace('%2F', '/', rawurlencode($uri)) : '/';
 
 		if ($this->bucket !== '')

--- a/lib/S3.php
+++ b/lib/S3.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* $Id: S3.php 47 2009-07-20 01:25:40Z don.schonknecht $
+* $Id$
 *
-* Copyright (c) 2008, Donovan Schönknecht.  All rights reserved.
+* Copyright (c) 2013, Donovan Schonknecht.  All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -32,9 +32,10 @@
 * Amazon S3 PHP class
 *
 * @link http://undesigned.org.za/2007/10/22/amazon-s3-php-class
-* @version 0.4.0
+* @version 0.5.1 + Signature v4 support ;)
 */
-class S3 {
+class S3
+{
 	// ACL flags
 	const ACL_PRIVATE = 'private';
 	const ACL_PUBLIC_READ = 'public-read';
@@ -42,34 +43,237 @@ class S3 {
 	const ACL_AUTHENTICATED_READ = 'authenticated-read';
 
 	const LOCATION_US = '';
-	const LOCATION_EU = 'EU';
-	const LOCATION_US_WEST = 'us-west-1';
-	const LOCATION_AP_SOUTHEAST = 'ap-southeast-1';
 
-	const ORIGIN_TYPE_S3 = 'S3';
-	const ORIING_TYPE_CUSTOM = 'Custom';
+	const ORIGIN_TYPE_S3 = 's3';
+	const ORIGIN_TYPE_CUSTOM = 'custom';
 
-	public static $use_ssl = true;
+	const STORAGE_CLASS_STANDARD = 'STANDARD';
+	const STORAGE_CLASS_RRS = 'REDUCED_REDUNDANCY';
+	const STORAGE_CLASS_STANDARD_IA = 'STANDARD_IA';
 
-	private static $__accessKey; // AWS Access key
-	private static $__secretKey; // AWS Secret key
-	private static $__api_host;  // AWS host where API is located
+	const SSE_NONE = '';
+	const SSE_AES256 = 'AES256';
 
+	/**
+	 * The AWS Access key
+	 *
+	 * @var string
+	 * @access private
+	 * @static
+	 */
+	private static $__accessKey = null;
+
+	/**
+	 * AWS Secret Key
+	 *
+	 * @var string
+	 * @access private
+	 * @static
+	 */
+	private static $__secretKey = null;
+
+	/**
+	 * SSL Client key
+	 *
+	 * @var string
+	 * @access private
+	 * @static
+	 */
+	private static $__sslKey = null;
+
+	/**
+	 * Default delimiter to be used, for example while getBucket().
+	 * @var string
+	 * @access public
+	 * @static 
+	 */
+	public static $defDelimiter = null;
+
+	/**
+	 * AWS URI
+	 *
+	 * @var string
+	 * @acess public
+	 * @static
+	 */
+	public static $endpoint = 's3.amazonaws.com';
+
+	/**
+	 * AWS Region
+	 *
+	 * @var string
+	 * @acess public
+	 * @static
+	 */
+	public static $region = '';
+
+	/**
+	 * Proxy information
+	 *
+	 * @var null|array
+	 * @access public
+	 * @static
+	 */
+	public static $proxy = null;
+
+	/**
+	 * Connect using SSL?
+	 *
+	 * @var bool
+	 * @access public
+	 * @static
+	 */
+	public static $useSSL = false;
+
+	/**
+	 * Use SSL validation?
+	 *
+	 * @var bool
+	 * @access public
+	 * @static
+	 */
+	public static $useSSLValidation = true;
+
+	/**
+	 * Use SSL version
+	 *
+	 * @var const
+	 * @access public
+	 * @static
+	 */
+	public static $useSSLVersion = 1; //CURL_SSLVERSION_TLSv1;
+
+	/**
+	 * Use PHP exceptions?
+	 *
+	 * @var bool
+	 * @access public
+	 * @static
+	 */
+	public static $useExceptions = false;
+
+	/**
+	 * Time offset applied to time()
+	 * @access private
+	 * @static
+	 */
+	private static $__timeOffset = 0;
+
+	/**
+	 * SSL client key
+	 *
+	 * @var bool
+	 * @access public
+	 * @static
+	 */
+	public static $sslKey = null;
+	
+	/**
+	 * SSL client certfificate
+	 *
+	 * @var string
+	 * @acess public
+	 * @static
+	 */
+	public static $sslCert = null;
+	
+	/**
+	 * SSL CA cert (only required if you are having problems with your system CA cert)
+	 *
+	 * @var string
+	 * @access public
+	 * @static
+	 */
+	public static $sslCACert = null;
+	
+	/**
+	 * AWS Key Pair ID
+	 *
+	 * @var string
+	 * @access private
+	 * @static
+	 */
+	private static $__signingKeyPairId = null;
+	
+	/**
+	 * Key resource, freeSigningKey() must be called to clear it from memory
+	 *
+	 * @var bool
+	 * @access private
+	 * @static 
+	 */
+	private static $__signingKeyResource = false;
+
+	/**
+	 * AWS Signature Version
+	 *
+	 * @var string
+	 * @acess public
+	 * @static
+	 */
+	public static $signVer = 'v4';
 
 	/**
 	* Constructor - if you're not using the class statically
 	*
 	* @param string $accessKey Access key
 	* @param string $secretKey Secret key
-	* @param boolean $use_ssl Enable SSL
+	* @param boolean $useSSL Enable SSL
+	* @param string $endpoint Amazon URI
 	* @return void
 	*/
-	public function __construct($accessKey = null, $secretKey = null, 
-			$use_ssl = true, $api_host = 's3.amazonaws.com') {
+	public function __construct($accessKey = null, $secretKey = null, $useSSL = false, $endpoint = 's3.amazonaws.com', $region = '')
+	{
 		if ($accessKey !== null && $secretKey !== null)
-			self::setAuth($accessKey, $secretKey, $api_host);
-		self::$use_ssl = $use_ssl;
-		self::$__api_host = $api_host;
+			self::setAuth($accessKey, $secretKey);
+		self::$useSSL = $useSSL;
+		self::$endpoint = $endpoint;
+		self::$region = $region;
+	}
+
+
+	/**
+	* Set the service endpoint
+	*
+	* @param string $host Hostname
+	* @return void
+	*/
+	public function setEndpoint($host)
+	{
+		self::$endpoint = $host;
+	}
+
+
+	/**
+	* Set the service region
+	*
+	* @param string $region
+	* @return void
+	*/
+	public function setRegion($region)
+	{
+		self::$region = $region;
+	}
+
+
+	/**
+	* Get the service region
+	*
+	* @return string $region
+	* @static
+	*/
+	public static function getRegion()
+	{
+		$region = self::$region;
+
+		// parse region from endpoint if not specific
+		if (empty($region)) {
+			if (preg_match("/s3[.-](?:website-|dualstack\.)?(.+)\.amazonaws\.com/i",self::$endpoint,$match) !== 0 && strtolower($match[1]) !== "external-1") {
+				$region = $match[1];
+			}		
+		}
+
+		return empty($region) ? 'us-east-1' : $region;
 	}
 
 
@@ -80,9 +284,162 @@ class S3 {
 	* @param string $secretKey Secret key
 	* @return void
 	*/
-	public static function setAuth($accessKey, $secretKey) {
+	public static function setAuth($accessKey, $secretKey)
+	{
 		self::$__accessKey = $accessKey;
 		self::$__secretKey = $secretKey;
+	}
+
+
+	/**
+	* Check if AWS keys have been set
+	*
+	* @return boolean
+	*/
+	public static function hasAuth() {
+		return (self::$__accessKey !== null && self::$__secretKey !== null);
+	}
+
+
+	/**
+	* Set SSL on or off
+	*
+	* @param boolean $enabled SSL enabled
+	* @param boolean $validate SSL certificate validation
+	* @return void
+	*/
+	public static function setSSL($enabled, $validate = true)
+	{
+		self::$useSSL = $enabled;
+		self::$useSSLValidation = $validate;
+	}
+
+
+	/**
+	* Set SSL client certificates (experimental)
+	*
+	* @param string $sslCert SSL client certificate
+	* @param string $sslKey SSL client key
+	* @param string $sslCACert SSL CA cert (only required if you are having problems with your system CA cert)
+	* @return void
+	*/
+	public static function setSSLAuth($sslCert = null, $sslKey = null, $sslCACert = null)
+	{
+		self::$sslCert = $sslCert;
+		self::$sslKey = $sslKey;
+		self::$sslCACert = $sslCACert;
+	}
+
+
+	/**
+	* Set proxy information
+	*
+	* @param string $host Proxy hostname and port (localhost:1234)
+	* @param string $user Proxy username
+	* @param string $pass Proxy password
+	* @param constant $type CURL proxy type
+	* @return void
+	*/
+	public static function setProxy($host, $user = null, $pass = null, $type = CURLPROXY_SOCKS5)
+	{
+		self::$proxy = array('host' => $host, 'type' => $type, 'user' => $user, 'pass' => $pass);
+	}
+
+
+	/**
+	* Set the error mode to exceptions
+	*
+	* @param boolean $enabled Enable exceptions
+	* @return void
+	*/
+	public static function setExceptions($enabled = true)
+	{
+		self::$useExceptions = $enabled;
+	}
+
+
+	/**
+	* Set AWS time correction offset (use carefully)
+	*
+	* This can be used when an inaccurate system time is generating
+	* invalid request signatures.  It should only be used as a last
+	* resort when the system time cannot be changed.
+	*
+	* @param string $offset Time offset (set to zero to use AWS server time)
+	* @return void
+	*/
+	public static function setTimeCorrectionOffset($offset = 0)
+	{
+		if ($offset == 0)
+		{
+			$rest = new S3Request('HEAD');
+			$rest = $rest->getResponse();
+			$awstime = $rest->headers['date'];
+			$systime = time();			
+			$offset = $systime > $awstime ? -($systime - $awstime) : ($awstime - $systime);
+		}
+		self::$__timeOffset = $offset;
+	}
+
+
+	/**
+	* Set signing key
+	*
+	* @param string $keyPairId AWS Key Pair ID
+	* @param string $signingKey Private Key
+	* @param boolean $isFile Load private key from file, set to false to load string
+	* @return boolean
+	*/
+	public static function setSigningKey($keyPairId, $signingKey, $isFile = true)
+	{
+		self::$__signingKeyPairId = $keyPairId;
+		if ((self::$__signingKeyResource = openssl_pkey_get_private($isFile ?
+		file_get_contents($signingKey) : $signingKey)) !== false) return true;
+		self::triggerError('S3::setSigningKey(): Unable to open load private key: '.$signingKey, __FILE__, __LINE__);
+		return false;
+	}
+
+
+	/**
+	* Set Signature Version
+	*
+	* @param string $version of signature ('v4' or 'v2')
+	* @return void
+	*/
+	public static function setSignatureVersion($version = 'v2')
+	{
+		self::$signVer = $version;
+	}
+
+
+	/**
+	* Free signing key from memory, MUST be called if you are using setSigningKey()
+	*
+	* @return void
+	*/
+	public static function freeSigningKey()
+	{
+		if (self::$__signingKeyResource !== false)
+			openssl_free_key(self::$__signingKeyResource);
+	}
+
+
+	/**
+	* Internal error handler
+	*
+	* @internal Internal error handler
+	* @param string $message Error message
+	* @param string $file Filename
+	* @param integer $line Line number
+	* @param integer $code Error code
+	* @return void
+	*/
+	private static function triggerError($message, $file, $line, $code = 0)
+	{
+		if (self::$useExceptions)
+			throw new S3Exception($message, $file, $line, $code);
+		else
+			trigger_error($message, E_USER_WARNING);
 	}
 
 
@@ -92,25 +449,26 @@ class S3 {
 	* @param boolean $detailed Returns detailed bucket list when true
 	* @return array | false
 	*/
-	public static function listBuckets($detailed = false) {
-		$rest = new S3Request('GET', '', '', self::$__api_host);
+	public static function listBuckets($detailed = false)
+	{
+		$rest = new S3Request('GET', '', '', self::$endpoint);
 		$rest = $rest->getResponse();
 		if ($rest->error === false && $rest->code !== 200)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::listBuckets(): [%s] %s",
-                $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::listBuckets(): [%s] %s", $rest->error['code'],
+			$rest->error['message']), __FILE__, __LINE__);
 			return false;
 		}
 		$results = array();
 		if (!isset($rest->body->Buckets)) return $results;
 
-		if ($detailed) {
+		if ($detailed)
+		{
 			if (isset($rest->body->Owner, $rest->body->Owner->ID, $rest->body->Owner->DisplayName))
 			$results['owner'] = array(
-				'id' => (string)$rest->body->Owner->ID, 'name' => (string)$rest->body->Owner->ID
+				'id' => (string)$rest->body->Owner->ID, 'name' => (string)$rest->body->Owner->DisplayName
 			);
 			$results['buckets'] = array();
 			foreach ($rest->body->Buckets->Bucket as $b)
@@ -125,6 +483,99 @@ class S3 {
 
 
 	/**
+	* Get contents for a bucket
+	*
+	* If maxKeys is null this method will loop through truncated result sets
+	*
+	* @param string $bucket Bucket name
+	* @param string $prefix Prefix
+	* @param string $marker Marker (last file listed)
+	* @param string $maxKeys Max keys (maximum number of keys to return)
+	* @param string $delimiter Delimiter
+	* @param boolean $returnCommonPrefixes Set to true to return CommonPrefixes
+	* @return array | false
+	*/
+	public static function getBucket($bucket, $prefix = null, $marker = null, $maxKeys = null, $delimiter = null, $returnCommonPrefixes = false)
+	{
+		$rest = new S3Request('GET', $bucket, '', self::$endpoint);
+		if ($maxKeys == 0) $maxKeys = null;
+		if ($prefix !== null && $prefix !== '') $rest->setParameter('prefix', $prefix);
+		if ($marker !== null && $marker !== '') $rest->setParameter('marker', $marker);
+		if ($maxKeys !== null && $maxKeys !== '') $rest->setParameter('max-keys', $maxKeys);
+		if ($delimiter !== null && $delimiter !== '') $rest->setParameter('delimiter', $delimiter);
+		else if (!empty(self::$defDelimiter)) $rest->setParameter('delimiter', self::$defDelimiter);
+		$response = $rest->getResponse();
+		if ($response->error === false && $response->code !== 200)
+			$response->error = array('code' => $response->code, 'message' => 'Unexpected HTTP status');
+		if ($response->error !== false)
+		{
+			self::triggerError(sprintf("S3::getBucket(): [%s] %s",
+			$response->error['code'], $response->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+
+		$results = array();
+
+		$nextMarker = null;
+		if (isset($response->body, $response->body->Contents))
+		foreach ($response->body->Contents as $c)
+		{
+			$results[(string)$c->Key] = array(
+				'name' => (string)$c->Key,
+				'time' => strtotime((string)$c->LastModified),
+				'size' => (int)$c->Size,
+				'hash' => substr((string)$c->ETag, 1, -1)
+			);
+			$nextMarker = (string)$c->Key;
+		}
+
+		if ($returnCommonPrefixes && isset($response->body, $response->body->CommonPrefixes))
+			foreach ($response->body->CommonPrefixes as $c)
+				$results[(string)$c->Prefix] = array('prefix' => (string)$c->Prefix);
+
+		if (isset($response->body, $response->body->IsTruncated) &&
+		(string)$response->body->IsTruncated == 'false') return $results;
+
+		if (isset($response->body, $response->body->NextMarker))
+			$nextMarker = (string)$response->body->NextMarker;
+
+		// Loop through truncated results if maxKeys isn't specified
+		if ($maxKeys == null && $nextMarker !== null && (string)$response->body->IsTruncated == 'true')
+		do
+		{
+			$rest = new S3Request('GET', $bucket, '', self::$endpoint);
+			if ($prefix !== null && $prefix !== '') $rest->setParameter('prefix', $prefix);
+			$rest->setParameter('marker', $nextMarker);
+			if ($delimiter !== null && $delimiter !== '') $rest->setParameter('delimiter', $delimiter);
+
+			if (($response = $rest->getResponse()) == false || $response->code !== 200) break;
+
+			if (isset($response->body, $response->body->Contents))
+			foreach ($response->body->Contents as $c)
+			{
+				$results[(string)$c->Key] = array(
+					'name' => (string)$c->Key,
+					'time' => strtotime((string)$c->LastModified),
+					'size' => (int)$c->Size,
+					'hash' => substr((string)$c->ETag, 1, -1)
+				);
+				$nextMarker = (string)$c->Key;
+			}
+
+			if ($returnCommonPrefixes && isset($response->body, $response->body->CommonPrefixes))
+				foreach ($response->body->CommonPrefixes as $c)
+					$results[(string)$c->Prefix] = array('prefix' => (string)$c->Prefix);
+
+			if (isset($response->body, $response->body->NextMarker))
+				$nextMarker = (string)$response->body->NextMarker;
+
+		} while ($response !== false && (string)$response->body->IsTruncated == 'true');
+
+		return $results;
+	}
+
+
+	/**
 	* Put a bucket
 	*
 	* @param string $bucket Bucket name
@@ -132,11 +583,15 @@ class S3 {
 	* @param string $location Set as "EU" to create buckets hosted in Europe
 	* @return boolean
 	*/
-	public static function putBucket($bucket, $acl = self::ACL_PRIVATE, $location = false) {
-		$rest = new S3Request('PUT', $bucket, '', self::$__api_host);
+	public static function putBucket($bucket, $acl = self::ACL_PRIVATE, $location = false)
+	{
+		$rest = new S3Request('PUT', $bucket, '', self::$endpoint);
 		$rest->setAmzHeader('x-amz-acl', $acl);
 
-		if ($location) {
+		if (empty($location)) $location = self::getRegion();
+
+		if ($location !== false && $location !== "us-east-1")
+		{
 			$dom = new DOMDocument;
 			$createBucketConfiguration = $dom->createElement('CreateBucketConfiguration');
 			$locationConstraint = $dom->createElement('LocationConstraint', $location);
@@ -150,14 +605,32 @@ class S3 {
 
 		if ($rest->error === false && $rest->code !== 200)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::putBucket('%s', '%s', '%s'): [%s] %s",
-                $bucket,
-                $acl,
-                $location,
-			    $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::putBucket({$bucket}, {$acl}, {$location}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
+	* Delete an empty bucket
+	*
+	* @param string $bucket Bucket name
+	* @return boolean
+	*/
+	public static function deleteBucket($bucket)
+	{
+		$rest = new S3Request('DELETE', $bucket, '', self::$endpoint);
+		$rest = $rest->getResponse();
+		if ($rest->error === false && $rest->code !== 204)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::deleteBucket({$bucket}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
 			return false;
 		}
 		return true;
@@ -171,14 +644,49 @@ class S3 {
 	* @param mixed $md5sum Use MD5 hash (supply a string if you want to use your own)
 	* @return array | false
 	*/
-	private static function inputFile($file, $md5sum = true) {
-		if (!file_exists($file) || !is_file($file) || !is_readable($file)) {
-			trigger_error('S3::inputFile(): Unable to open input file: '.$file, E_USER_WARNING);
+	public static function inputFile($file, $md5sum = true)
+	{
+		if (!file_exists($file) || !is_file($file) || !is_readable($file))
+		{
+			self::triggerError('S3::inputFile(): Unable to open input file: '.$file, __FILE__, __LINE__);
 			return false;
 		}
-		return array('file' => $file, 'size' => filesize($file),
-		'md5sum' => $md5sum !== false ? (is_string($md5sum) ? $md5sum :
-		base64_encode(md5_file($file, true))) : '');
+		clearstatcache(false, $file);
+		return array('file' => $file, 'size' => filesize($file), 'md5sum' => $md5sum !== false ?
+		(is_string($md5sum) ? $md5sum : base64_encode(md5_file($file, true))) : '', 'sha256sum' => hash_file('sha256', $file));
+	}
+
+
+	/**
+	* Create input array info for putObject() with a resource
+	*
+	* @param string $resource Input resource to read from
+	* @param integer $bufferSize Input byte size
+	* @param string $md5sum MD5 hash to send (optional)
+	* @return array | false
+	*/
+	public static function inputResource(&$resource, $bufferSize = false, $md5sum = '')
+	{
+		if (!is_resource($resource) || (int)$bufferSize < 0)
+		{
+			self::triggerError('S3::inputResource(): Invalid resource or buffer size', __FILE__, __LINE__);
+			return false;
+		}
+
+		// Try to figure out the bytesize
+		if ($bufferSize === false)
+		{
+			if (fseek($resource, 0, SEEK_END) < 0 || ($bufferSize = ftell($resource)) === false)
+			{
+				self::triggerError('S3::inputResource(): Unable to obtain resource size', __FILE__, __LINE__);
+				return false;
+			}
+			fseek($resource, 0);
+		}
+
+		$input = array('size' => $bufferSize, 'md5sum' => $md5sum);
+		$input['fp'] =& $resource;
+		return $input;
 	}
 
 
@@ -191,15 +699,19 @@ class S3 {
 	* @param constant $acl ACL constant
 	* @param array $metaHeaders Array of x-amz-meta-* headers
 	* @param array $requestHeaders Array of request headers or content type as a string
+	* @param constant $storageClass Storage class constant
+	* @param constant $serverSideEncryption Server-side encryption
 	* @return boolean
 	*/
-	public static function putObject($input, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $requestHeaders = array()) {
+	public static function putObject($input, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $requestHeaders = array(), $storageClass = self::STORAGE_CLASS_STANDARD, $serverSideEncryption = self::SSE_NONE)
+	{
 		if ($input === false) return false;
-		$rest = new S3Request('PUT', $bucket, $uri, self::$__api_host);
+		$rest = new S3Request('PUT', $bucket, $uri, self::$endpoint);
 
-		if (is_string($input)) $input = array(
+		if (!is_array($input)) $input = array(
 			'data' => $input, 'size' => strlen($input),
-			'md5sum' => base64_encode(md5($input, true))
+			'md5sum' => base64_encode(md5($input, true)),
+			'sha256sum' => hash('sha256', $input)
 		);
 
 		// Data
@@ -214,32 +726,45 @@ class S3 {
 		if (isset($input['size']) && $input['size'] >= 0)
 			$rest->size = $input['size'];
 		else {
-			if (isset($input['file']))
+			if (isset($input['file'])) {
+				clearstatcache(false, $input['file']);
 				$rest->size = filesize($input['file']);
+			}
 			elseif (isset($input['data']))
 				$rest->size = strlen($input['data']);
 		}
 
 		// Custom request headers (Content-Type, Content-Disposition, Content-Encoding)
 		if (is_array($requestHeaders))
-			foreach ($requestHeaders as $h => $v) $rest->setHeader($h, $v);
+			foreach ($requestHeaders as $h => $v)
+				strpos($h, 'x-amz-') === 0 ? $rest->setAmzHeader($h, $v) : $rest->setHeader($h, $v);
 		elseif (is_string($requestHeaders)) // Support for legacy contentType parameter
 			$input['type'] = $requestHeaders;
 
 		// Content-Type
-		if (!isset($input['type'])) {
+		if (!isset($input['type']))
+		{
 			if (isset($requestHeaders['Content-Type']))
 				$input['type'] =& $requestHeaders['Content-Type'];
 			elseif (isset($input['file']))
-				$input['type'] = self::_getMimeType($input['file']);
+				$input['type'] = self::getMIMEType($input['file']);
 			else
 				$input['type'] = 'application/octet-stream';
 		}
 
+		if ($storageClass !== self::STORAGE_CLASS_STANDARD) // Storage class
+			$rest->setAmzHeader('x-amz-storage-class', $storageClass);
+
+		if ($serverSideEncryption !== self::SSE_NONE) // Server-side encryption
+			$rest->setAmzHeader('x-amz-server-side-encryption', $serverSideEncryption);
+
 		// We need to post with Content-Length and Content-Type, MD5 is optional
-		if ($rest->size >= 0 && ($rest->fp !== false || $rest->data !== false)) {
+		if ($rest->size >= 0 && ($rest->fp !== false || $rest->data !== false))
+		{
 			$rest->setHeader('Content-Type', $input['type']);
 			if (isset($input['md5sum'])) $rest->setHeader('Content-MD5', $input['md5sum']);
+
+			if (isset($input['sha256sum'])) $rest->setAmzHeader('x-amz-content-sha256', $input['sha256sum']);
 
 			$rest->setAmzHeader('x-amz-acl', $acl);
 			foreach ($metaHeaders as $h => $v) $rest->setAmzHeader('x-amz-meta-'.$h, $v);
@@ -249,11 +774,10 @@ class S3 {
 
 		if ($rest->response->error === false && $rest->response->code !== 200)
 			$rest->response->error = array('code' => $rest->response->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->response->error !== false) {
-			trigger_error(sprintf("S3::putObject(): [%s] %s",
-                $rest->response->error['code'],
-                $rest->response->error['message']
-            ), E_USER_WARNING);
+		if ($rest->response->error !== false)
+		{
+			self::triggerError(sprintf("S3::putObject(): [%s] %s",
+			$rest->response->error['code'], $rest->response->error['message']), __FILE__, __LINE__);
 			return false;
 		}
 		return true;
@@ -271,7 +795,8 @@ class S3 {
 	* @param string $contentType Content type
 	* @return boolean
 	*/
-	public static function putObjectFile($file, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $contentType = null) {
+	public static function putObjectFile($file, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $contentType = null)
+	{
 		return self::putObject(self::inputFile($file), $bucket, $uri, $acl, $metaHeaders, $contentType);
 	}
 
@@ -287,7 +812,8 @@ class S3 {
 	* @param string $contentType Content type
 	* @return boolean
 	*/
-	public static function putObjectString($string, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $contentType = 'text/plain') {
+	public static function putObjectString($string, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $contentType = 'text/plain')
+	{
 		return self::putObject($string, $bucket, $uri, $acl, $metaHeaders, $contentType);
 	}
 
@@ -300,9 +826,11 @@ class S3 {
 	* @param mixed $saveTo Filename or resource to write to
 	* @return mixed
 	*/
-	public static function getObject($bucket, $uri, $saveTo = false) {
-		$rest = new S3Request('GET', $bucket, $uri, self::$__api_host);
-		if ($saveTo !== false) {
+	public static function getObject($bucket, $uri, $saveTo = false)
+	{
+		$rest = new S3Request('GET', $bucket, $uri, self::$endpoint);
+		if ($saveTo !== false)
+		{
 			if (is_resource($saveTo))
 				$rest->fp =& $saveTo;
 			else
@@ -315,14 +843,10 @@ class S3 {
 
 		if ($rest->response->error === false && $rest->response->code !== 200)
 			$rest->response->error = array('code' => $rest->response->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->response->error !== false) {
-			trigger_error(sprintf("S3::getObject('%s', '%s', '%s'): [%s] %s",
-                $bucket,
-                $uri,
-                $saveTo,
-			    $rest->response->error['code'],
-                $rest->response->error['message']
-            ), E_USER_WARNING);
+		if ($rest->response->error !== false)
+		{
+			self::triggerError(sprintf("S3::getObject({$bucket}, {$uri}): [%s] %s",
+			$rest->response->error['code'], $rest->response->error['message']), __FILE__, __LINE__);
 			return false;
 		}
 		return $rest->response;
@@ -337,22 +861,359 @@ class S3 {
 	* @param boolean $returnInfo Return response information
 	* @return mixed | false
 	*/
-	public static function getObjectInfo($bucket, $uri, $returnInfo = true) {
-		$rest = new S3Request('HEAD', $bucket, $uri, self::$__api_host);
+	public static function getObjectInfo($bucket, $uri, $returnInfo = true)
+	{
+		$rest = new S3Request('HEAD', $bucket, $uri, self::$endpoint);
 		$rest = $rest->getResponse();
 		if ($rest->error === false && ($rest->code !== 200 && $rest->code !== 404))
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::getObjectInfo('%s', '%s', %d): [%s] %s",
-                $bucket,
-                $uri,
-                $returnInfo,
-			    $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::getObjectInfo({$bucket}, {$uri}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
 			return false;
 		}
 		return $rest->code == 200 ? $returnInfo ? $rest->headers : true : false;
+	}
+
+
+	/**
+	* Copy an object
+	*
+	* @param string $srcBucket Source bucket name
+	* @param string $srcUri Source object URI
+	* @param string $bucket Destination bucket name
+	* @param string $uri Destination object URI
+	* @param constant $acl ACL constant
+	* @param array $metaHeaders Optional array of x-amz-meta-* headers
+	* @param array $requestHeaders Optional array of request headers (content type, disposition, etc.)
+	* @param constant $storageClass Storage class constant
+	* @return mixed | false
+	*/
+	public static function copyObject($srcBucket, $srcUri, $bucket, $uri, $acl = self::ACL_PRIVATE, $metaHeaders = array(), $requestHeaders = array(), $storageClass = self::STORAGE_CLASS_STANDARD)
+	{
+		$rest = new S3Request('PUT', $bucket, $uri, self::$endpoint);
+		$rest->setHeader('Content-Length', 0);
+		foreach ($requestHeaders as $h => $v)
+				strpos($h, 'x-amz-') === 0 ? $rest->setAmzHeader($h, $v) : $rest->setHeader($h, $v);
+		foreach ($metaHeaders as $h => $v) $rest->setAmzHeader('x-amz-meta-'.$h, $v);
+		if ($storageClass !== self::STORAGE_CLASS_STANDARD) // Storage class
+			$rest->setAmzHeader('x-amz-storage-class', $storageClass);
+		$rest->setAmzHeader('x-amz-acl', $acl);
+		$rest->setAmzHeader('x-amz-copy-source', sprintf('/%s/%s', $srcBucket, rawurlencode($srcUri)));
+		if (sizeof($requestHeaders) > 0 || sizeof($metaHeaders) > 0)
+			$rest->setAmzHeader('x-amz-metadata-directive', 'REPLACE');
+
+		$rest = $rest->getResponse();
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::copyObject({$srcBucket}, {$srcUri}, {$bucket}, {$uri}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		return isset($rest->body->LastModified, $rest->body->ETag) ? array(
+			'time' => strtotime((string)$rest->body->LastModified),
+			'hash' => substr((string)$rest->body->ETag, 1, -1)
+		) : false;
+	}
+
+
+	/**
+	* Set up a bucket redirection
+	*
+	* @param string $bucket Bucket name
+	* @param string $location Target host name
+	* @return boolean
+	*/
+	public static function setBucketRedirect($bucket = NULL, $location = NULL)
+	{
+		$rest = new S3Request('PUT', $bucket, '', self::$endpoint);
+
+		if( empty($bucket) || empty($location) ) {
+			self::triggerError("S3::setBucketRedirect({$bucket}, {$location}): Empty parameter.", __FILE__, __LINE__);
+			return false;
+		}
+
+		$dom = new DOMDocument;
+		$websiteConfiguration = $dom->createElement('WebsiteConfiguration');
+		$redirectAllRequestsTo = $dom->createElement('RedirectAllRequestsTo');
+		$hostName = $dom->createElement('HostName', $location);
+		$redirectAllRequestsTo->appendChild($hostName);
+		$websiteConfiguration->appendChild($redirectAllRequestsTo);
+		$dom->appendChild($websiteConfiguration);
+		$rest->setParameter('website', null);
+		$rest->data = $dom->saveXML();
+		$rest->size = strlen($rest->data);
+		$rest->setHeader('Content-Type', 'application/xml');
+		$rest = $rest->getResponse();
+
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::setBucketRedirect({$bucket}, {$location}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
+	* Set logging for a bucket
+	*
+	* @param string $bucket Bucket name
+	* @param string $targetBucket Target bucket (where logs are stored)
+	* @param string $targetPrefix Log prefix (e,g; domain.com-)
+	* @return boolean
+	*/
+	public static function setBucketLogging($bucket, $targetBucket, $targetPrefix = null)
+	{
+		// The S3 log delivery group has to be added to the target bucket's ACP
+		if ($targetBucket !== null && ($acp = self::getAccessControlPolicy($targetBucket, '')) !== false)
+		{
+			// Only add permissions to the target bucket when they do not exist
+			$aclWriteSet = false;
+			$aclReadSet = false;
+			foreach ($acp['acl'] as $acl)
+			if ($acl['type'] == 'Group' && $acl['uri'] == 'http://acs.amazonaws.com/groups/s3/LogDelivery')
+			{
+				if ($acl['permission'] == 'WRITE') $aclWriteSet = true;
+				elseif ($acl['permission'] == 'READ_ACP') $aclReadSet = true;
+			}
+			if (!$aclWriteSet) $acp['acl'][] = array(
+				'type' => 'Group', 'uri' => 'http://acs.amazonaws.com/groups/s3/LogDelivery', 'permission' => 'WRITE'
+			);
+			if (!$aclReadSet) $acp['acl'][] = array(
+				'type' => 'Group', 'uri' => 'http://acs.amazonaws.com/groups/s3/LogDelivery', 'permission' => 'READ_ACP'
+			);
+			if (!$aclReadSet || !$aclWriteSet) self::setAccessControlPolicy($targetBucket, '', $acp);
+		}
+
+		$dom = new DOMDocument;
+		$bucketLoggingStatus = $dom->createElement('BucketLoggingStatus');
+		$bucketLoggingStatus->setAttribute('xmlns', 'http://s3.amazonaws.com/doc/2006-03-01/');
+		if ($targetBucket !== null)
+		{
+			if ($targetPrefix == null) $targetPrefix = $bucket . '-';
+			$loggingEnabled = $dom->createElement('LoggingEnabled');
+			$loggingEnabled->appendChild($dom->createElement('TargetBucket', $targetBucket));
+			$loggingEnabled->appendChild($dom->createElement('TargetPrefix', $targetPrefix));
+			// TODO: Add TargetGrants?
+			$bucketLoggingStatus->appendChild($loggingEnabled);
+		}
+		$dom->appendChild($bucketLoggingStatus);
+
+		$rest = new S3Request('PUT', $bucket, '', self::$endpoint);
+		$rest->setParameter('logging', null);
+		$rest->data = $dom->saveXML();
+		$rest->size = strlen($rest->data);
+		$rest->setHeader('Content-Type', 'application/xml');
+		$rest = $rest->getResponse();
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::setBucketLogging({$bucket}, {$targetBucket}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
+	* Get logging status for a bucket
+	*
+	* This will return false if logging is not enabled.
+	* Note: To enable logging, you also need to grant write access to the log group
+	*
+	* @param string $bucket Bucket name
+	* @return array | false
+	*/
+	public static function getBucketLogging($bucket)
+	{
+		$rest = new S3Request('GET', $bucket, '', self::$endpoint);
+		$rest->setParameter('logging', null);
+		$rest = $rest->getResponse();
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::getBucketLogging({$bucket}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		if (!isset($rest->body->LoggingEnabled)) return false; // No logging
+		return array(
+			'targetBucket' => (string)$rest->body->LoggingEnabled->TargetBucket,
+			'targetPrefix' => (string)$rest->body->LoggingEnabled->TargetPrefix,
+		);
+	}
+
+
+	/**
+	* Disable bucket logging
+	*
+	* @param string $bucket Bucket name
+	* @return boolean
+	*/
+	public static function disableBucketLogging($bucket)
+	{
+		return self::setBucketLogging($bucket, null);
+	}
+
+
+	/**
+	* Get a bucket's location
+	*
+	* @param string $bucket Bucket name
+	* @return string | false
+	*/
+	public static function getBucketLocation($bucket)
+	{
+		$rest = new S3Request('GET', $bucket, '', self::$endpoint);
+		$rest->setParameter('location', null);
+		$rest = $rest->getResponse();
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::getBucketLocation({$bucket}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		return (isset($rest->body[0]) && (string)$rest->body[0] !== '') ? (string)$rest->body[0] : 'US';
+	}
+
+
+	/**
+	* Set object or bucket Access Control Policy
+	*
+	* @param string $bucket Bucket name
+	* @param string $uri Object URI
+	* @param array $acp Access Control Policy Data (same as the data returned from getAccessControlPolicy)
+	* @return boolean
+	*/
+	public static function setAccessControlPolicy($bucket, $uri = '', $acp = array())
+	{
+		$dom = new DOMDocument;
+		$dom->formatOutput = true;
+		$accessControlPolicy = $dom->createElement('AccessControlPolicy');
+		$accessControlList = $dom->createElement('AccessControlList');
+
+		// It seems the owner has to be passed along too
+		$owner = $dom->createElement('Owner');
+		$owner->appendChild($dom->createElement('ID', $acp['owner']['id']));
+		$owner->appendChild($dom->createElement('DisplayName', $acp['owner']['name']));
+		$accessControlPolicy->appendChild($owner);
+
+		foreach ($acp['acl'] as $g)
+		{
+			$grant = $dom->createElement('Grant');
+			$grantee = $dom->createElement('Grantee');
+			$grantee->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+			if (isset($g['id']))
+			{ // CanonicalUser (DisplayName is omitted)
+				$grantee->setAttribute('xsi:type', 'CanonicalUser');
+				$grantee->appendChild($dom->createElement('ID', $g['id']));
+			}
+			elseif (isset($g['email']))
+			{ // AmazonCustomerByEmail
+				$grantee->setAttribute('xsi:type', 'AmazonCustomerByEmail');
+				$grantee->appendChild($dom->createElement('EmailAddress', $g['email']));
+			}
+			elseif ($g['type'] == 'Group')
+			{ // Group
+				$grantee->setAttribute('xsi:type', 'Group');
+				$grantee->appendChild($dom->createElement('URI', $g['uri']));
+			}
+			$grant->appendChild($grantee);
+			$grant->appendChild($dom->createElement('Permission', $g['permission']));
+			$accessControlList->appendChild($grant);
+		}
+
+		$accessControlPolicy->appendChild($accessControlList);
+		$dom->appendChild($accessControlPolicy);
+
+		$rest = new S3Request('PUT', $bucket, $uri, self::$endpoint);
+		$rest->setParameter('acl', null);
+		$rest->data = $dom->saveXML();
+		$rest->size = strlen($rest->data);
+		$rest->setHeader('Content-Type', 'application/xml');
+		$rest = $rest->getResponse();
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::setAccessControlPolicy({$bucket}, {$uri}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
+	* Get object or bucket Access Control Policy
+	*
+	* @param string $bucket Bucket name
+	* @param string $uri Object URI
+	* @return mixed | false
+	*/
+	public static function getAccessControlPolicy($bucket, $uri = '')
+	{
+		$rest = new S3Request('GET', $bucket, $uri, self::$endpoint);
+		$rest->setParameter('acl', null);
+		$rest = $rest->getResponse();
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::getAccessControlPolicy({$bucket}, {$uri}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+
+		$acp = array();
+		if (isset($rest->body->Owner, $rest->body->Owner->ID, $rest->body->Owner->DisplayName))
+			$acp['owner'] = array(
+				'id' => (string)$rest->body->Owner->ID, 'name' => (string)$rest->body->Owner->DisplayName
+			);
+
+		if (isset($rest->body->AccessControlList))
+		{
+			$acp['acl'] = array();
+			foreach ($rest->body->AccessControlList->Grant as $grant)
+			{
+				foreach ($grant->Grantee as $grantee)
+				{
+					if (isset($grantee->ID, $grantee->DisplayName)) // CanonicalUser
+						$acp['acl'][] = array(
+							'type' => 'CanonicalUser',
+							'id' => (string)$grantee->ID,
+							'name' => (string)$grantee->DisplayName,
+							'permission' => (string)$grant->Permission
+						);
+					elseif (isset($grantee->EmailAddress)) // AmazonCustomerByEmail
+						$acp['acl'][] = array(
+							'type' => 'AmazonCustomerByEmail',
+							'email' => (string)$grantee->EmailAddress,
+							'permission' => (string)$grant->Permission
+						);
+					elseif (isset($grantee->URI)) // Group
+						$acp['acl'][] = array(
+							'type' => 'Group',
+							'uri' => (string)$grantee->URI,
+							'permission' => (string)$grant->Permission
+						);
+					else continue;
+				}
+			}
+		}
+		return $acp;
 	}
 
 
@@ -363,18 +1224,16 @@ class S3 {
 	* @param string $uri Object URI
 	* @return boolean
 	*/
-	public static function deleteObject($bucket, $uri) {
-		$rest = new S3Request('DELETE', $bucket, $uri, self::$__api_host);
+	public static function deleteObject($bucket, $uri)
+	{
+		$rest = new S3Request('DELETE', $bucket, $uri, self::$endpoint);
 		$rest = $rest->getResponse();
 		if ($rest->error === false && $rest->code !== 204)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::deleteObject('%s', '%s'): [%s] %s",
-                $bucket,
-                $uri,
-			    $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::deleteObject(): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
 			return false;
 		}
 		return true;
@@ -382,42 +1241,186 @@ class S3 {
 
 
 	/**
+	* Get a query string authenticated URL
+	*
+	* @param string $bucket Bucket name
+	* @param string $uri Object URI
+	* @param integer $lifetime Lifetime in seconds
+	* @param boolean $hostBucket Use the bucket name as the hostname
+	* @param boolean $https Use HTTPS ($hostBucket should be false for SSL verification)
+	* @return string
+	*/
+	public static function getAuthenticatedURL($bucket, $uri, $lifetime, $hostBucket = false, $https = false)
+	{
+		$expires = self::getTime() + $lifetime;
+		$uri = str_replace(array('%2F', '%2B'), array('/', '+'), rawurlencode($uri));
+		return sprintf(($https ? 'https' : 'http').'://%s/%s?AWSAccessKeyId=%s&Expires=%u&Signature=%s',
+		// $hostBucket ? $bucket : $bucket.'.s3.amazonaws.com', $uri, self::$__accessKey, $expires,
+		$hostBucket ? $bucket : self::$endpoint.'/'.$bucket, $uri, self::$__accessKey, $expires,
+		urlencode(self::getHash("GET\n\n\n{$expires}\n/{$bucket}/{$uri}")));
+	}
+
+
+	/**
+	* Get a CloudFront signed policy URL
+	*
+	* @param array $policy Policy
+	* @return string
+	*/
+	public static function getSignedPolicyURL($policy)
+	{
+		$data = json_encode($policy);
+		$signature = '';
+		if (!openssl_sign($data, $signature, self::$__signingKeyResource)) return false;
+
+		$encoded = str_replace(array('+', '='), array('-', '_', '~'), base64_encode($data));
+		$signature = str_replace(array('+', '='), array('-', '_', '~'), base64_encode($signature));
+
+		$url = $policy['Statement'][0]['Resource'] . '?';
+		foreach (array('Policy' => $encoded, 'Signature' => $signature, 'Key-Pair-Id' => self::$__signingKeyPairId) as $k => $v)
+			$url .= $k.'='.str_replace('%2F', '/', rawurlencode($v)).'&';
+		return substr($url, 0, -1);
+	}
+
+
+	/**
+	* Get a CloudFront canned policy URL
+	*
+	* @param string $url URL to sign
+	* @param integer $lifetime URL lifetime
+	* @return string
+	*/
+	public static function getSignedCannedURL($url, $lifetime)
+	{
+		return self::getSignedPolicyURL(array(
+			'Statement' => array(
+				array('Resource' => $url, 'Condition' => array(
+					'DateLessThan' => array('AWS:EpochTime' => self::getTime() + $lifetime)
+				))
+			)
+		));
+	}
+
+
+	/**
+	* Get upload POST parameters for form uploads
+	*
+	* @param string $bucket Bucket name
+	* @param string $uriPrefix Object URI prefix
+	* @param constant $acl ACL constant
+	* @param integer $lifetime Lifetime in seconds
+	* @param integer $maxFileSize Maximum filesize in bytes (default 5MB)
+	* @param string $successRedirect Redirect URL or 200 / 201 status code
+	* @param array $amzHeaders Array of x-amz-meta-* headers
+	* @param array $headers Array of request headers or content type as a string
+	* @param boolean $flashVars Includes additional "Filename" variable posted by Flash
+	* @return object
+	*/
+	public static function getHttpUploadPostParams($bucket, $uriPrefix = '', $acl = self::ACL_PRIVATE, $lifetime = 3600,
+	$maxFileSize = 5242880, $successRedirect = "201", $amzHeaders = array(), $headers = array(), $flashVars = false)
+	{
+		// Create policy object
+		$policy = new stdClass;
+		$policy->expiration = gmdate('Y-m-d\TH:i:s\Z', (self::getTime() + $lifetime));
+		$policy->conditions = array();
+		$obj = new stdClass; $obj->bucket = $bucket; array_push($policy->conditions, $obj);
+		$obj = new stdClass; $obj->acl = $acl; array_push($policy->conditions, $obj);
+
+		$obj = new stdClass; // 200 for non-redirect uploads
+		if (is_numeric($successRedirect) && in_array((int)$successRedirect, array(200, 201)))
+			$obj->success_action_status = (string)$successRedirect;
+		else // URL
+			$obj->success_action_redirect = $successRedirect;
+		array_push($policy->conditions, $obj);
+
+		if ($acl !== self::ACL_PUBLIC_READ)
+			array_push($policy->conditions, array('eq', '$acl', $acl));
+
+		array_push($policy->conditions, array('starts-with', '$key', $uriPrefix));
+		if ($flashVars) array_push($policy->conditions, array('starts-with', '$Filename', ''));
+		foreach (array_keys($headers) as $headerKey)
+			array_push($policy->conditions, array('starts-with', '$'.$headerKey, ''));
+		foreach ($amzHeaders as $headerKey => $headerVal)
+		{
+			$obj = new stdClass;
+			$obj->{$headerKey} = (string)$headerVal;
+			array_push($policy->conditions, $obj);
+		}
+		array_push($policy->conditions, array('content-length-range', 0, $maxFileSize));
+		$policy = base64_encode(str_replace('\/', '/', json_encode($policy)));
+
+		// Create parameters
+		$params = new stdClass;
+		$params->AWSAccessKeyId = self::$__accessKey;
+		$params->key = $uriPrefix.'${filename}';
+		$params->acl = $acl;
+		$params->policy = $policy; unset($policy);
+		$params->signature = self::getHash($params->policy);
+		if (is_numeric($successRedirect) && in_array((int)$successRedirect, array(200, 201)))
+			$params->success_action_status = (string)$successRedirect;
+		else
+			$params->success_action_redirect = $successRedirect;
+		foreach ($headers as $headerKey => $headerVal) $params->{$headerKey} = (string)$headerVal;
+		foreach ($amzHeaders as $headerKey => $headerVal) $params->{$headerKey} = (string)$headerVal;
+		return $params;
+	}
+
+
+	/**
 	* Create a CloudFront distribution
 	*
-	* @param string $dnsName Origin DNS name
-	* @param string $originType Origin Type
+	* @param string $bucket Bucket name
+    * @param string $originType origin type (s3 or custom)
 	* @param boolean $enabled Enabled (true/false)
 	* @param array $cnames Array containing CNAME aliases
 	* @param string $comment Use the bucket name as the hostname
+	* @param string $defaultRootObject Default root object
+	* @param string $originAccessIdentity Origin access identity
+	* @param array $trustedSigners Array of trusted signers
 	* @return array | false
 	*/
-	public static function createDistribution($dnsName, $originType = self::ORIGIN_TYPE_S3, $enabled = true, $cnames = array(), $comment = '') {
-		self::$use_ssl = true; // CloudFront requires SSL
-		$rest = new S3Request('POST', '', '2010-11-01/distribution', 
-			'cloudfront.amazonaws.com');
-		$rest->data = self::_getCloudFrontDistributionConfigXML($dnsName, 
-			$originType, $enabled, $comment, (string)microtime(true), $cnames);
+	public static function createDistribution($bucket, $originType = self::ORIGIN_TYPE_S3, $enabled = true, $cnames = array(), $comment = null, $defaultRootObject = null, $originAccessIdentity = null, $trustedSigners = array())
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::createDistribution({$bucket}, ".(int)$enabled.", [], '$comment'): %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+		$useSSL = self::$useSSL;
+
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('POST', '', '2010-11-01/distribution', 'cloudfront.amazonaws.com');
+		$rest->data = self::getCloudFrontDistributionConfigXML(
+			$bucket,
+			$originType,
+			$enabled,
+			(string)$comment,
+			(string)microtime(true),
+			$cnames,
+			$defaultRootObject,
+			$originAccessIdentity,
+			$trustedSigners
+		);
+
 		$rest->size = strlen($rest->data);
 		$rest->setHeader('Content-Type', 'application/xml');
-		$rest = self::_getCloudFrontResponse($rest);
+		$rest = self::getCloudFrontResponse($rest);
+
+		self::$useSSL = $useSSL;
 
 		if ($rest->error === false && $rest->code !== 201)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::createDistribution('%s', '%s', %d, '%s', '%s'): [%s] %s",
-                $dnsName,
-                $originType,
-                $enabled,
-                implode(', ', $cnames),
-                $comment,
-    			$rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::createDistribution({$bucket}, ".(int)$enabled.", [], '$comment'): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
 			return false;
 		} elseif ($rest->body instanceof SimpleXMLElement)
-			return self::_parseCloudFrontDistributionConfig($rest->body);
+			return self::parseCloudFrontDistributionConfig($rest->body);
 		return false;
 	}
+
 
 	/**
 	* Get CloudFront distribution info
@@ -425,25 +1428,35 @@ class S3 {
 	* @param string $distributionId Distribution ID from listDistributions()
 	* @return array | false
 	*/
-	public static function getDistribution($distributionId) {
-		self::$use_ssl = true; // CloudFront requires SSL
-		$rest = new S3Request('GET', '', 
-			'2010-11-01/distribution/' . $distributionId, 
-			'cloudfront.amazonaws.com');
-		$rest = self::_getCloudFrontResponse($rest);
+	public static function getDistribution($distributionId)
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::getDistribution($distributionId): %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+		$useSSL = self::$useSSL;
+
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('GET', '', '2010-11-01/distribution/'.$distributionId, 'cloudfront.amazonaws.com');
+		$rest = self::getCloudFrontResponse($rest);
+
+		self::$useSSL = $useSSL;
 
 		if ($rest->error === false && $rest->code !== 200)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::getDistribution(%d): [%s] %s",
-                $distributionId,
-			    $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::getDistribution($distributionId): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
 			return false;
-		} elseif ($rest->body instanceof SimpleXMLElement) {
-			$dist = self::_parseCloudFrontDistributionConfig($rest->body);
+		}
+		elseif ($rest->body instanceof SimpleXMLElement)
+		{
+			$dist = self::parseCloudFrontDistributionConfig($rest->body);
 			$dist['hash'] = $rest->headers['hash'];
+			$dist['id'] = $distributionId;
 			return $dist;
 		}
 		return false;
@@ -456,27 +1469,46 @@ class S3 {
 	* @param array $dist Distribution array info identical to output of getDistribution()
 	* @return array | false
 	*/
-	public static function updateDistribution($dist) {
-		self::$use_ssl = true; // CloudFront requires SSL
-		$rest = new S3Request('PUT', '', 
-			'2010-11-01/distribution/' . $dist['id'] . '/config',
-			'cloudfront.amazonaws.com');
-		$rest->data = self::_getCloudFrontDistributionConfigXML($dist['origin'], $dist['type'], $dist['enabled'], $dist['comment'], $dist['callerReference'], $dist['cnames']);
+	public static function updateDistribution($dist)
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::updateDistribution({$dist['id']}): %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+
+		$useSSL = self::$useSSL;
+
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('PUT', '', '2010-11-01/distribution/'.$dist['id'].'/config', 'cloudfront.amazonaws.com');
+		$rest->data = self::getCloudFrontDistributionConfigXML(
+			$dist['origin'],
+			$dist['type'],
+			$dist['enabled'],
+			$dist['comment'],
+			$dist['callerReference'],
+			$dist['cnames'],
+			$dist['defaultRootObject'],
+			$dist['originAccessIdentity'],
+			$dist['trustedSigners']
+		);
+
 		$rest->size = strlen($rest->data);
 		$rest->setHeader('If-Match', $dist['hash']);
-		$rest = self::_getCloudFrontResponse($rest);
+		$rest = self::getCloudFrontResponse($rest);
+
+		self::$useSSL = $useSSL;
 
 		if ($rest->error === false && $rest->code !== 200)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::updateDistribution('%s'): [%s] %s",
-                serialize($dist),
-			    $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::updateDistribution({$dist['id']}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
 			return false;
 		} else {
-			$dist = self::_parseCloudFrontDistributionConfig($rest->body);
+			$dist = self::parseCloudFrontDistributionConfig($rest->body);
 			$dist['hash'] = $rest->headers['hash'];
 			return $dist;
 		}
@@ -485,34 +1517,231 @@ class S3 {
 
 
 	/**
+	* Delete a CloudFront distribution
+	*
+	* @param array $dist Distribution array info identical to output of getDistribution()
+	* @return boolean
+	*/
+	public static function deleteDistribution($dist)
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::deleteDistribution({$dist['id']}): %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+
+		$useSSL = self::$useSSL;
+
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('DELETE', '', '2008-06-30/distribution/'.$dist['id'], 'cloudfront.amazonaws.com');
+		$rest->setHeader('If-Match', $dist['hash']);
+		$rest = self::getCloudFrontResponse($rest);
+
+		self::$useSSL = $useSSL;
+
+		if ($rest->error === false && $rest->code !== 204)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::deleteDistribution({$dist['id']}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
 	* Get a list of CloudFront distributions
 	*
 	* @return array
 	*/
-	public static function listDistributions() {
-		self::$use_ssl = true; // CloudFront requires SSL
-		$rest = new S3Request('GET', '', '2010-11-01/distribution',
-			'cloudfront.amazonaws.com');
-		$rest = self::_getCloudFrontResponse($rest);
+	public static function listDistributions()
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::listDistributions(): [%s] %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+
+		$useSSL = self::$useSSL;
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('GET', '', '2010-11-01/distribution', 'cloudfront.amazonaws.com');
+		$rest = self::getCloudFrontResponse($rest);
+		self::$useSSL = $useSSL;
 
 		if ($rest->error === false && $rest->code !== 200)
 			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-		if ($rest->error !== false) {
-			trigger_error(sprintf("S3::listDistributions(): [%s] %s",
-			    $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
+		if ($rest->error !== false)
+		{
+			self::triggerError(sprintf("S3::listDistributions(): [%s] %s",
+			$rest->error['code'], $rest->error['message']), __FILE__, __LINE__);
 			return false;
-		} elseif ($rest->body instanceof SimpleXMLElement && isset($rest->body->DistributionSummary)) {
+		}
+		elseif ($rest->body instanceof SimpleXMLElement && isset($rest->body->DistributionSummary))
+		{
 			$list = array();
-			if (isset($rest->body->Marker, $rest->body->MaxItems, $rest->body->IsTruncated)) {
+			if (isset($rest->body->Marker, $rest->body->MaxItems, $rest->body->IsTruncated))
+			{
 				//$info['marker'] = (string)$rest->body->Marker;
 				//$info['maxItems'] = (int)$rest->body->MaxItems;
 				//$info['isTruncated'] = (string)$rest->body->IsTruncated == 'true' ? true : false;
 			}
-			foreach ($rest->body->DistributionSummary as $summary) {
-				$list[(string)$summary->Id] = self::_parseCloudFrontDistributionConfig($summary);
-			}
+			foreach ($rest->body->DistributionSummary as $summary)
+				$list[(string)$summary->Id] = self::parseCloudFrontDistributionConfig($summary);
+
+			return $list;
+		}
+		return array();
+	}
+
+	/**
+	* List CloudFront Origin Access Identities
+	*
+	* @return array
+	*/
+	public static function listOriginAccessIdentities()
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::listOriginAccessIdentities(): [%s] %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('GET', '', '2010-11-01/origin-access-identity/cloudfront', 'cloudfront.amazonaws.com');
+		$rest = self::getCloudFrontResponse($rest);
+		$useSSL = self::$useSSL;
+
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			trigger_error(sprintf("S3::listOriginAccessIdentities(): [%s] %s",
+			$rest->error['code'], $rest->error['message']), E_USER_WARNING);
+			return false;
+		}
+
+		if (isset($rest->body->CloudFrontOriginAccessIdentitySummary))
+		{
+			$identities = array();
+			foreach ($rest->body->CloudFrontOriginAccessIdentitySummary as $identity)
+				if (isset($identity->S3CanonicalUserId))
+					$identities[(string)$identity->Id] = array('id' => (string)$identity->Id, 's3CanonicalUserId' => (string)$identity->S3CanonicalUserId);
+			return $identities;
+		}
+		return false;
+	}
+
+
+	/**
+	* Invalidate objects in a CloudFront distribution
+	*
+	* Thanks to Martin Lindkvist for S3::invalidateDistribution()
+	*
+	* @param string $distributionId Distribution ID from listDistributions()
+	* @param array $paths Array of object paths to invalidate
+	* @return boolean
+	*/
+	public static function invalidateDistribution($distributionId, $paths)
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::invalidateDistribution(): [%s] %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+
+		$useSSL = self::$useSSL;
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('POST', '', '2010-08-01/distribution/'.$distributionId.'/invalidation', 'cloudfront.amazonaws.com');
+		$rest->data = self::getCloudFrontInvalidationBatchXML($paths, (string)microtime(true));
+		$rest->size = strlen($rest->data);
+		$rest = self::getCloudFrontResponse($rest);
+		self::$useSSL = $useSSL;
+
+		if ($rest->error === false && $rest->code !== 201)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			trigger_error(sprintf("S3::invalidate('{$distributionId}',{$paths}): [%s] %s",
+			$rest->error['code'], $rest->error['message']), E_USER_WARNING);
+			return false;
+		}
+		return true;
+	}
+
+
+	/**
+	* Get a InvalidationBatch DOMDocument
+	*
+	* @internal Used to create XML in invalidateDistribution()
+	* @param array $paths Paths to objects to invalidateDistribution
+	* @param int $callerReference
+	* @return string
+	*/
+	private static function getCloudFrontInvalidationBatchXML($paths, $callerReference = '0')
+	{
+		$dom = new DOMDocument('1.0', 'UTF-8');
+		$dom->formatOutput = true;
+		$invalidationBatch = $dom->createElement('InvalidationBatch');
+		foreach ($paths as $path)
+			$invalidationBatch->appendChild($dom->createElement('Path', $path));
+
+		$invalidationBatch->appendChild($dom->createElement('CallerReference', $callerReference));
+		$dom->appendChild($invalidationBatch);
+		return $dom->saveXML();
+	}
+
+
+	/**
+	* List your invalidation batches for invalidateDistribution() in a CloudFront distribution
+	*
+	* http://docs.amazonwebservices.com/AmazonCloudFront/latest/APIReference/ListInvalidation.html
+	* returned array looks like this:
+	*	Array
+	*	(
+	*		[I31TWB0CN9V6XD] => InProgress
+	*		[IT3TFE31M0IHZ] => Completed
+	*		[I12HK7MPO1UQDA] => Completed
+	*		[I1IA7R6JKTC3L2] => Completed
+	*	)
+	*
+	* @param string $distributionId Distribution ID from listDistributions()
+	* @return array
+	*/
+	public static function getDistributionInvalidationList($distributionId)
+	{
+		if (!extension_loaded('openssl'))
+		{
+			self::triggerError(sprintf("S3::getDistributionInvalidationList(): [%s] %s",
+			"CloudFront functionality requires SSL"), __FILE__, __LINE__);
+			return false;
+		}
+
+		$useSSL = self::$useSSL;
+		self::$useSSL = true; // CloudFront requires SSL
+		$rest = new S3Request('GET', '', '2010-11-01/distribution/'.$distributionId.'/invalidation', 'cloudfront.amazonaws.com');
+		$rest = self::getCloudFrontResponse($rest);
+		self::$useSSL = $useSSL;
+
+		if ($rest->error === false && $rest->code !== 200)
+			$rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
+		if ($rest->error !== false)
+		{
+			trigger_error(sprintf("S3::getDistributionInvalidationList('{$distributionId}'): [%s]",
+			$rest->error['code'], $rest->error['message']), E_USER_WARNING);
+			return false;
+		}
+		elseif ($rest->body instanceof SimpleXMLElement && isset($rest->body->InvalidationSummary))
+		{
+			$list = array();
+			foreach ($rest->body->InvalidationSummary as $summary)
+				$list[(string)$summary->Id] = (string)$summary->Status;
+
 			return $list;
 		}
 		return array();
@@ -522,45 +1751,56 @@ class S3 {
 	/**
 	* Get a DistributionConfig DOMDocument
 	*
+	* http://docs.amazonwebservices.com/AmazonCloudFront/latest/APIReference/index.html?PutConfig.html
+	*
 	* @internal Used to create XML in createDistribution() and updateDistribution()
-	* @param string $dnsName Origin DNS name
-	* @param string $originType Origin type
+	* @param string $bucket S3 Origin bucket
+    * @param string $originType origin type (s3 or custom)
 	* @param boolean $enabled Enabled (true/false)
 	* @param string $comment Comment to append
 	* @param string $callerReference Caller reference
 	* @param array $cnames Array of CNAME aliases
+	* @param string $defaultRootObject Default root object
+	* @param string $originAccessIdentity Origin access identity
+	* @param array $trustedSigners Array of trusted signers
 	* @return string
 	*/
-	private static function _getCloudFrontDistributionConfigXML($dnsName, $originType, $enabled, $comment, $callerReference = '0', $cnames = array()) {
+	private static function getCloudFrontDistributionConfigXML($bucket, $originType, $enabled, $comment, $callerReference = '0', $cnames = array(), $defaultRootObject = null, $originAccessIdentity = null, $trustedSigners = array())
+	{
 		$dom = new DOMDocument('1.0', 'UTF-8');
-
-        $dom->formatOutput = true;
+		$dom->formatOutput = true;
 		$distributionConfig = $dom->createElement('DistributionConfig');
 		$distributionConfig->setAttribute('xmlns', 'http://cloudfront.amazonaws.com/doc/2010-11-01/');
 
-		if ($originType == 's3') {
+		if ($originType == self::ORIGIN_TYPE_S3) {
 			$origin = $dom->createElement('S3Origin');
-			$origin->appendChild($dom->createElement('DNSName', $dnsName));
+			$origin->appendChild($dom->createElement('DNSName', $bucket));
 		} else {
 			$origin = $dom->createElement('CustomOrigin');
-			$origin->appendChild($dom->createElement('DNSName', $dnsName));
+			$origin->appendChild($dom->createElement('DNSName', $bucket));
 			$origin->appendChild($dom->createElement('OriginProtocolPolicy', 'http-only'));
 		}
-
+		
+		if ($originAccessIdentity !== null) $origin->appendChild($dom->createElement('OriginAccessIdentity', $originAccessIdentity));
 		$distributionConfig->appendChild($origin);
+
+		if ($defaultRootObject !== null) $distributionConfig->appendChild($dom->createElement('DefaultRootObject', $defaultRootObject));
+
 		$distributionConfig->appendChild($dom->createElement('CallerReference', $callerReference));
-
-		foreach ($cnames as $cname) {
+		foreach ($cnames as $cname)
 			$distributionConfig->appendChild($dom->createElement('CNAME', $cname));
-        }
-
-		if ($comment !== '') {
-            $distributionConfig->appendChild($dom->createElement('Comment', $comment));
-        }
-
+		if ($comment !== '') $distributionConfig->appendChild($dom->createElement('Comment', $comment));
 		$distributionConfig->appendChild($dom->createElement('Enabled', $enabled ? 'true' : 'false'));
-		$dom->appendChild($distributionConfig);
 
+        if (!empty($trustedSigners)) {
+            $trusted = $dom->createElement('TrustedSigners');
+            foreach ($trustedSigners as $id => $type)
+                $trusted->appendChild($id !== '' ? $dom->createElement($type, $id) : $dom->createElement($type));
+            $distributionConfig->appendChild($trusted);
+        }
+
+		$dom->appendChild($distributionConfig);
+		//var_dump($dom->saveXML());
 		return $dom->saveXML();
 	}
 
@@ -568,168 +1808,75 @@ class S3 {
 	/**
 	* Parse a CloudFront distribution config
 	*
+	* See http://docs.amazonwebservices.com/AmazonCloudFront/latest/APIReference/index.html?GetDistribution.html
+	*
 	* @internal Used to parse the CloudFront DistributionConfig node to an array
 	* @param object &$node DOMNode
 	* @return array
 	*/
-	private static function _parseCloudFrontDistributionConfig(&$node) {
+	private static function parseCloudFrontDistributionConfig(&$node)
+	{
+		if (isset($node->DistributionConfig))
+			return self::parseCloudFrontDistributionConfig($node->DistributionConfig);
+
 		$dist = array();
+		if (isset($node->Id, $node->Status, $node->LastModifiedTime, $node->DomainName))
+		{
+			$dist['id'] = (string)$node->Id;
+			$dist['status'] = (string)$node->Status;
+			$dist['time'] = strtotime((string)$node->LastModifiedTime);
+			$dist['domain'] = (string)$node->DomainName;
+		}
 
-        if (isset($node->Id)) {
-            $dist['id'] = (string) $node->Id;
-        }
+		if (isset($node->CallerReference))
+			$dist['callerReference'] = (string)$node->CallerReference;
 
-        if (isset($node->Status)) {
-            $dist['status'] = (string) $node->Status;
-        }
+		if (isset($node->Enabled))
+			$dist['enabled'] = (string)$node->Enabled == 'true' ? true : false;
 
-        if (isset($node->LastModifiedTime)) {
-            $dist['time'] = strtotime((string) $node->LastModifiedTime);
-        }
-
-        if (isset($node->DomainName)) {
-            $dist['domain'] = (string) $node->DomainName;
-        }
-
-        if (isset($node->S3Origin)) {
-            $dist['type'] = 's3';
-
+		if (isset($node->S3Origin))
+		{
+            $dist['type'] = self::ORIGIN_TYPE_S3;
+			
             if (isset($node->S3Origin->DNSName)) {
-                $dist['origin'] = (string) $node->S3Origin->DNSName;
+                $dist['origin'] = (string)$node->S3Origin->DNSName;
             }
+
+            $dist['originAccessIdentity'] = isset($node->S3Origin->OriginAccessIdentity) ?
+            (string)$node->S3Origin->OriginAccessIdentity : null;
         } elseif (isset($node->CustomOrigin)) {
-            $dist['type'] = 'custom';
+            $dist['type'] = self::ORIGIN_TYPE_CUSTOM;
 
             if (isset($node->CustomOrigin->DNSName)) {
                 $dist['origin'] = (string) $node->CustomOrigin->DNSName;
             }
+
+            $dist['originAccessIdentity'] = isset($node->S3Origin->OriginAccessIdentity) ?
+            (string)$node->S3Origin->OriginAccessIdentity : null;
         }
 
-        if (isset($node->CallerReference)) {
-            $dist['callerReference'] = (string) $node->CallerReference;
-        }
+		$dist['defaultRootObject'] = isset($node->DefaultRootObject) ? (string)$node->DefaultRootObject : null;
 
-        if (isset($node->CNAME)) {
-            $dist['cnames'] = array();
+		$dist['cnames'] = array();
+		if (isset($node->CNAME))
+			foreach ($node->CNAME as $cname)
+				$dist['cnames'][(string)$cname] = (string)$cname;
 
-            foreach ($node->CNAME as $cname) {
-                $dist['cnames'][] = (string) $cname;
-            }
-        }
+		$dist['trustedSigners'] = array();
+		if (isset($node->TrustedSigners))
+			foreach ($node->TrustedSigners as $signer)
+			{
+				if (isset($signer->Self))
+					$dist['trustedSigners'][''] = 'Self';
+				elseif (isset($signer->KeyPairId))
+					$dist['trustedSigners'][(string)$signer->KeyPairId] = 'KeyPairId';
+				elseif (isset($signer->AwsAccountNumber))
+					$dist['trustedSigners'][(string)$signer->AwsAccountNumber] = 'AwsAccountNumber';
+			}
 
-        if (isset($node->Comment)) {
-            $dist['comment'] = (string) $node->Comment;
-        }
-
-        if (isset($node->Enabled)) {
-            $dist['enabled'] = ((string) $node->Enabled == 'true' ? true : false);
-        }
-
-        if (isset($node->DistributionConfig)) {
-            $dist = array_merge($dist, self::_parseCloudFrontDistributionConfig($node->DistributionConfig));
-        }
-
+		$dist['comment'] = isset($node->Comment) ? (string)$node->Comment : null;
 		return $dist;
 	}
-
-
-    /**
-     * Creates invalidation bath
-     *
-     * @static
-     * @param integer $distributionId
-     * @param array $paths
-     * @return array|bool
-     */
-    public static function createInvalidation($distributionId, $paths) {
-        self::$use_ssl = true; // CloudFront requires SSL
-
-        $rest = new S3Request('POST', '', 
-        	'2010-11-01/distribution/' . $distributionId . '/invalidation',
-        	'cloudfront.amazonaws.com');
-
-        $rest->data = self::_getCloudFrontInvalidationBath($paths);
-        $rest->size = strlen($rest->data);
-        $rest->setHeader('Content-Type', 'application/xml');
-
-        $rest = self::_getCloudFrontResponse($rest);
-
-        if ($rest->error === false && $rest->code !== 201) {
-            $rest->error = array('code' => $rest->code, 'message' => 'Unexpected HTTP status');
-        }
-
-        if ($rest->error !== false) {
-            trigger_error(sprintf("S3::createInvalidation(%d, '%s'): [%s] %s",
-                $distributionId,
-                implode(', ', $paths),
-                $rest->error['code'],
-                $rest->error['message']
-            ), E_USER_WARNING);
-            return false;
-        } elseif ($rest->body instanceof SimpleXMLElement) {
-            return self::_parseCloudFrontInvalidation($rest->body);
-        }
-
-        return false;
-    }
-
-
-    /**
-     * Returns invalidation bath XML
-     *
-     * @static
-     * @param array $files
-     * @return string
-     */
-    private static function _getCloudFrontInvalidationBath($paths) {
-        $dom = new DOMDocument('1.0', 'UTF-8');
-        $dom->formatOutput = true;
-
-        $invalidationBath = $dom->createElement('InvalidationBatch');
-
-        foreach ($paths as $path) {
-            $invalidationBath->appendChild($dom->createElement('Path', $path));
-        }
-
-        $invalidationBath->appendChild($dom->createElement('CallerReference', date('YmdHis')));
-        $dom->appendChild($invalidationBath);
-
-        return $dom->saveXML();
-    }
-
-
-    /**
-     * Parse CloudFront invalidation XML
-     *
-     * @static
-     * @param DOMNode $node
-     * @return array
-     */
-    private static function _parseCloudFrontInvalidation(&$node) {
-        $invalidation = array();
-
-        if (isset($node->Id)) {
-            $invalidation['id'] = $node->Id;
-        }
-
-        if (isset($node->Status)) {
-            $invalidation['status'] = $node->Status;
-        }
-
-        if (isset($node->CreateTime)) {
-            $invalidation['createTime'] = $node->CreateTime;
-        }
-
-        if (isset($node->InvalidationBatch)) {
-            $invalidation['invalidationBath'] = array();
-
-            foreach ($node->InvalidationBatch as $path) {
-                $invalidation['invalidationBath'][] = $path;
-            }
-        }
-
-        return $invalidation;
-    }
 
 
 	/**
@@ -739,14 +1886,17 @@ class S3 {
 	* @param object &$rest S3Request instance
 	* @return object
 	*/
-	private static function _getCloudFrontResponse(&$rest) {
+	private static function getCloudFrontResponse(&$rest)
+	{
 		$rest->getResponse();
 		if ($rest->response->error === false && isset($rest->response->body) &&
-		is_string($rest->response->body) && substr($rest->response->body, 0, 5) == '<?xml') {
+		is_string($rest->response->body) && substr($rest->response->body, 0, 5) == '<?xml')
+		{
 			$rest->response->body = simplexml_load_string($rest->response->body);
 			// Grab CloudFront errors
 			if (isset($rest->response->body->Error, $rest->response->body->Error->Code,
-			$rest->response->body->Error->Message)) {
+			$rest->response->body->Error->Message))
+			{
 				$rest->response->error = array(
 					'code' => (string)$rest->response->body->Error->Code,
 					'message' => (string)$rest->response->body->Error->Message
@@ -761,13 +1911,30 @@ class S3 {
 	/**
 	* Get MIME type for file
 	*
+	* To override the putObject() Content-Type, add it to $requestHeaders
+	*
+	* To use fileinfo, ensure the MAGIC environment variable is set
+	*
 	* @internal Used to get mime types
 	* @param string &$file File path
 	* @return string
 	*/
-	public static function _getMimeType(&$file) {
-		$type = Util_Mime::get_mime_type($file);
-		return $type;
+    private static function getMIMEType(&$file) {
+        $type = Util_Mime::get_mime_type($file);
+        return $type;
+    }
+
+
+	/**
+	* Get the current time
+	*
+	* @internal Used to apply offsets to sytem time
+	* @return integer
+	*/
+	public static function getTime()
+	{
+		self::setTimeCorrectionOffset();	// Set correct offset
+		return time() + self::$__timeOffset;
 	}
 
 
@@ -778,8 +1945,9 @@ class S3 {
 	* @param string $string String to sign
 	* @return string
 	*/
-	public static function _getSignature($string) {
-		return 'AWS '.self::$__accessKey.':'.self::_getHash($string);
+	public static function getSignature($string)
+	{
+		return 'AWS '.self::$__accessKey.':'.self::getHash($string);
 	}
 
 
@@ -788,11 +1956,12 @@ class S3 {
 	*
 	* This uses the hash extension if loaded
 	*
-	* @internal Used by _getSignature()
+	* @internal Used by getSignature()
 	* @param string $string String to sign
 	* @return string
 	*/
-	private static function _getHash($string) {
+	private static function getHash($string)
+	{
 		return base64_encode(extension_loaded('hash') ?
 		hash_hmac('sha1', $string, self::$__secretKey, true) : pack('H*', sha1(
 		(str_pad(self::$__secretKey, 64, chr(0x00)) ^ (str_repeat(chr(0x5c), 64))) .
@@ -800,28 +1969,215 @@ class S3 {
 		(str_repeat(chr(0x36), 64))) . $string)))));
 	}
 
+
+	/**
+	* Generate the headers for AWS Signature V4
+	* @internal Used by S3Request::getResponse()
+	* @param array $aheaders amzHeaders 
+	* @param array $headers
+	* @param string $method 
+	* @param string $uri
+	* @param string $data
+	* @param array $parameters
+	* @return array $headers
+	*/
+	public static function getSignatureV4($aHeaders, $headers, $method='GET', $uri='', $data = '', $parameters=array())
+	{		
+		$service = self::ORIGIN_TYPE_S3;
+		$region = S3::getRegion();
+		
+		$algorithm = 'AWS4-HMAC-SHA256';
+		$amzHeaders = array();
+		$amzRequests = array();
+		
+		$amzDate =  gmdate( 'Ymd\THis\Z' );
+		$amzDateStamp = gmdate( 'Ymd' );
+
+		// amz-date ISO8601 format ? for aws request		
+		$amzHeaders['x-amz-date'] = $amzDate;
+
+		// CanonicalHeaders
+		foreach ( $headers as $k => $v ) {
+			$amzHeaders[ strtolower( $k ) ] = trim( $v );
+		} 
+		foreach ( $aHeaders as $k => $v ) {
+			$amzHeaders[ strtolower( $k ) ] = trim( $v );
+		} 
+		uksort( $amzHeaders, 'strcmp' );
+
+		// payload
+		$payloadHash = isset($amzHeaders['x-amz-content-sha256']) ? $amzHeaders['x-amz-content-sha256'] :  hash('sha256', $data);
+
+		$uriQmPos = strpos($uri, '?');
+
+		// CanonicalRequests
+		$amzRequests[] = $method;
+		$amzRequests[] = ($uriQmPos === false ? $uri : substr($uri, 0, $uriQmPos));
+		$amzRequests[] = http_build_query($parameters);		
+		// add header as string to requests
+		foreach ( $amzHeaders as $k => $v ) {
+			$amzRequests[] = $k . ':' . $v;
+		}
+		// add a blank entry so we end up with an extra line break
+		$amzRequests[] = '';
+		// SignedHeaders
+		$amzRequests[] = implode( ';', array_keys( $amzHeaders ) );
+		// payload hash
+		$amzRequests[] = $payloadHash;
+		// request as string
+		$amzRequestStr = implode("\n", $amzRequests);
+		
+		// CredentialScope
+		$credentialScope = array();
+		$credentialScope[] = $amzDateStamp;
+		$credentialScope[] = $region;
+		$credentialScope[] = $service;
+		$credentialScope[] = 'aws4_request';
+
+		// stringToSign
+		$stringToSign = array();
+		$stringToSign[] = $algorithm;
+		$stringToSign[] = $amzDate;
+		$stringToSign[] = implode('/', $credentialScope);
+		$stringToSign[] =  hash('sha256', $amzRequestStr);
+		// as string
+		$stringToSignStr = implode("\n", $stringToSign);
+
+		// Make Signature
+		$kSecret = 'AWS4' . self::$__secretKey;
+		$kDate = hash_hmac( 'sha256', $amzDateStamp, $kSecret, true );
+		$kRegion = hash_hmac( 'sha256', $region, $kDate, true );
+		$kService = hash_hmac( 'sha256', $service, $kRegion, true );
+		$kSigning = hash_hmac( 'sha256', 'aws4_request', $kService, true );
+		
+		$signature = hash_hmac( 'sha256', $stringToSignStr, $kSigning );
+
+		$authorization = array(
+			'Credential=' . self::$__accessKey . '/' . implode( '/', $credentialScope ),
+			'SignedHeaders=' . implode( ';', array_keys( $amzHeaders ) ),
+			'Signature=' . $signature,
+		);
+
+		$authorizationStr = $algorithm . ' ' . implode( ',', $authorization );
+
+		$resultHeaders = array( 
+			'X-AMZ-DATE' => $amzDate,			
+			'Authorization' => $authorizationStr
+		);
+		if (!isset($aHeaders['x-amz-content-sha256'])) $resultHeaders['x-amz-content-sha256'] = $payloadHash;
+
+		return $resultHeaders;
+	}
+
+
 }
 
-
-
-class S3Request {
+/**
+ * S3 Request class 
+ *
+ * @link http://undesigned.org.za/2007/10/22/amazon-s3-php-class
+ * @version 0.5.0-dev
+ */
+final class S3Request
+{
+	/**
+	 * AWS URI
+	 *
+	 * @var string
+	 * @access private
+	 */
+	private $endpoint;
+	
+	/**
+	 * Verb
+	 *
+	 * @var string
+	 * @access private
+	 */
 	private $verb;
-    private $bucket;
-    private $uri;
-    private $resource = '';
-    private $parameters = array();
-    private	$amzHeaders = array();
+	
+	/**
+	 * S3 bucket name
+	 *
+	 * @var string
+	 * @access private
+	 */
+	private $bucket;
+	
+	/**
+	 * Object URI
+	 *
+	 * @var string
+	 * @access private
+	 */
+	private $uri;
+	
+	/**
+	 * Final object URI
+	 *
+	 * @var string
+	 * @access private
+	 */
+	private $resource = '';
+	
+	/**
+	 * Additional request parameters
+	 *
+	 * @var array
+	 * @access private
+	 */
+	private $parameters = array();
+	
+	/**
+	 * Amazon specific request headers
+	 *
+	 * @var array
+	 * @access private
+	 */
+	private $amzHeaders = array();
 
-    public $fp = false;
-    public $size = 0;
-    public $data = false;
-    public $response;
-    public $headers = array(
-		'Host' => '',
-        'Date' => '',
-        'Content-MD5' => '',
-        'Content-Type' => ''
+	/**
+	 * HTTP request headers
+	 *
+	 * @var array
+	 * @access private
+	 */
+	private $headers = array(
+		'Host' => '', 'Date' => '', 'Content-MD5' => '', 'Content-Type' => ''
 	);
+
+	/**
+	 * Use HTTP PUT?
+	 *
+	 * @var bool
+	 * @access public
+	 */
+	public $fp = false;
+
+	/**
+	 * PUT file size
+	 *
+	 * @var int
+	 * @access public
+	 */
+	public $size = 0;
+
+	/**
+	 * PUT post fields
+	 *
+	 * @var array
+	 * @access public
+	 */
+	public $data = false;
+
+	/**
+	 * S3 request respone
+	 *
+	 * @var object
+	 * @access public
+	 */
+	public $response;
+
 
 	/**
 	* Constructor
@@ -829,26 +2185,44 @@ class S3Request {
 	* @param string $verb Verb
 	* @param string $bucket Bucket name
 	* @param string $uri Object URI
+	* @param string $endpoint AWS endpoint URI
 	* @return mixed
 	*/
-	function __construct($verb, $bucket = '', $uri = '', 
-			$api_host = 's3.amazonaws.com') {
+	function __construct($verb, $bucket = '', $uri = '', $endpoint = 's3.amazonaws.com')
+	{
+		
+		$this->endpoint = $endpoint;
 		$this->verb = $verb;
 		$this->bucket = strtolower($bucket);
 		$this->uri = $uri !== '' ? '/'.str_replace('%2F', '/', rawurlencode($uri)) : '/';
 
-		if ($this->bucket !== '') {
-			$this->headers['Host'] = $this->bucket.'.'.$api_host;
-			$this->resource = '/'.$this->bucket.$this->uri;
-		} else {
-			$this->headers['Host'] = $api_host;
-			//$this->resource = strlen($this->uri) > 1 ? '/'.$this->bucket.$this->uri : $this->uri;
+		if ($this->bucket !== '')
+		{
+			if ($this->dnsBucketName($this->bucket))
+			{
+				$this->headers['Host'] = $this->bucket.'.'.$this->endpoint;
+				$this->resource = '/'.$this->bucket.$this->uri;
+			}
+			else
+			{
+				$this->headers['Host'] = $this->endpoint;
+				if ($this->bucket !== '') $this->uri = '/'.$this->bucket.$this->uri;
+				$this->bucket = '';
+				$this->resource = $this->uri;
+			}
+		}
+		else
+		{
+			$this->headers['Host'] = $this->endpoint;
 			$this->resource = $this->uri;
 		}
-		$this->headers['Date'] = gmdate('D, d M Y H:i:s T');
 
+
+		$this->headers['Date'] = gmdate('D, d M Y H:i:s T');
 		$this->response = new STDClass;
 		$this->response->error = false;
+		$this->response->body = null;
+		$this->response->headers = array();
 	}
 
 
@@ -859,7 +2233,8 @@ class S3Request {
 	* @param string $value Value
 	* @return void
 	*/
-	public function setParameter($key, $value) {
+	public function setParameter($key, $value)
+	{
 		$this->parameters[$key] = $value;
 	}
 
@@ -871,7 +2246,8 @@ class S3Request {
 	* @param string $value Value
 	* @return void
 	*/
-	public function setHeader($key, $value) {
+	public function setHeader($key, $value)
+	{
 		$this->headers[$key] = $value;
 	}
 
@@ -883,7 +2259,8 @@ class S3Request {
 	* @param string $value Value
 	* @return void
 	*/
-	public function setAmzHeader($key, $value) {
+	public function setAmzHeader($key, $value)
+	{
 		$this->amzHeaders[$key] = $value;
 	}
 
@@ -893,13 +2270,14 @@ class S3Request {
 	*
 	* @return object | false
 	*/
-	public function getResponse() {
+	public function getResponse()
+	{
 		$query = '';
-		if (sizeof($this->parameters) > 0) {
+		if (sizeof($this->parameters) > 0)
+		{
 			$query = substr($this->uri, -1) !== '?' ? '?' : '&';
 			foreach ($this->parameters as $var => $value)
 				if ($value == null || $value == '') $query .= $var.'&';
-				// Parameters should be encoded (thanks Sean O'Dea)
 				else $query .= $var.'='.rawurlencode($value).'&';
 			$query = substr($query, 0, -1);
 			$this->uri .= $query;
@@ -907,23 +2285,41 @@ class S3Request {
 			if (array_key_exists('acl', $this->parameters) ||
 			array_key_exists('location', $this->parameters) ||
 			array_key_exists('torrent', $this->parameters) ||
+			array_key_exists('website', $this->parameters) ||
 			array_key_exists('logging', $this->parameters))
 				$this->resource .= $query;
 		}
-		$url = ((S3::$use_ssl && extension_loaded('openssl')) ?
-		'https://':'http://').$this->headers['Host'].$this->uri;
-		//var_dump($this->bucket, $this->uri, $this->resource, $url);
+		$url = (S3::$useSSL ? 'https://' : 'http://') . ($this->headers['Host'] !== '' ? $this->headers['Host'] : $this->endpoint) . $this->uri;
+
+		//var_dump('bucket: ' . $this->bucket, 'uri: ' . $this->uri, 'resource: ' . $this->resource, 'url: ' . $url);
 
 		// Basic setup
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_USERAGENT, 'S3/php');
 
-		if (S3::$use_ssl) {
-			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
-			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+		if (S3::$useSSL)
+		{
+			// Set protocol version
+			curl_setopt($curl, CURLOPT_SSLVERSION, S3::$useSSLVersion);
+
+			// SSL Validation can now be optional for those with broken OpenSSL installations
+			curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, S3::$useSSLValidation ? 2 : 0);
+			curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, S3::$useSSLValidation ? 1 : 0);
+
+			if (S3::$sslKey !== null) curl_setopt($curl, CURLOPT_SSLKEY, S3::$sslKey);
+			if (S3::$sslCert !== null) curl_setopt($curl, CURLOPT_SSLCERT, S3::$sslCert);
+			if (S3::$sslCACert !== null) curl_setopt($curl, CURLOPT_CAINFO, S3::$sslCACert);
 		}
 
 		curl_setopt($curl, CURLOPT_URL, $url);
+
+		if (S3::$proxy != null && isset(S3::$proxy['host']))
+		{
+			curl_setopt($curl, CURLOPT_PROXY, S3::$proxy['host']);
+			curl_setopt($curl, CURLOPT_PROXYTYPE, S3::$proxy['type']);
+			if (isset(S3::$proxy['user'], S3::$proxy['pass']) && S3::$proxy['user'] != null && S3::$proxy['pass'] != null)
+				curl_setopt($curl, CURLOPT_PROXYUSERPWD, sprintf('%s:%s', S3::$proxy['user'], S3::$proxy['pass']));
+		}
 
 		// Headers
 		$headers = array(); $amz = array();
@@ -937,44 +2333,70 @@ class S3Request {
 			if (strlen($value) > 0) $amz[] = strtolower($header).':'.$value;
 
 		// AMZ headers must be sorted
-		if (sizeof($amz) > 0) {
-			sort($amz);
+		if (sizeof($amz) > 0)
+		{
+			//sort($amz);
+			usort($amz, array(&$this, 'sortMetaHeadersCmp'));
 			$amz = "\n".implode("\n", $amz);
 		} else $amz = '';
 
-		// Authorization string (CloudFront stringToSign should only contain a date)
-		$headers[] = 'Authorization: ' . S3::_getSignature(
-			$this->headers['Host'] == 'cloudfront.amazonaws.com' ? $this->headers['Date'] :
-			$this->verb . "\n" . 
-			$this->headers['Content-MD5'] . "\n" .
-			$this->headers['Content-Type'] . "\n" .
-			$this->headers['Date'] . 
-			$amz . "\n" . 
-			$this->resource
-		);
+		if (S3::hasAuth())
+		{
+			// Authorization string (CloudFront stringToSign should only contain a date)
+			if ($this->headers['Host'] == 'cloudfront.amazonaws.com')
+				$headers[] = 'Authorization: ' . S3::getSignature($this->headers['Date']);
+			else
+			{
+				if (S3::$signVer == 'v2')
+				{
+					$headers[] = 'Authorization: ' . S3::getSignature(
+						$this->verb."\n".
+						$this->headers['Content-MD5']."\n".
+						$this->headers['Content-Type']."\n".
+						$this->headers['Date'].$amz."\n".
+						$this->resource
+					);
+				} else {
+					$amzHeaders = S3::getSignatureV4(
+						$this->amzHeaders,
+						$this->headers, 
+						$this->verb, 
+						$this->uri,
+						$this->data,
+						$this->parameters
+					);
+					foreach ($amzHeaders as $k => $v) {
+						$headers[] = $k .': '. $v;
+					}
+				}
+			}
+		}
 
 		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 		curl_setopt($curl, CURLOPT_HEADER, false);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, false);
-		curl_setopt($curl, CURLOPT_WRITEFUNCTION, array(&$this, '_responseWriteCallback'));
-		curl_setopt($curl, CURLOPT_HEADERFUNCTION, array(&$this, '_responseHeaderCallback'));
-		@curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($curl, CURLOPT_WRITEFUNCTION, array(&$this, 'responseWriteCallback'));
+		curl_setopt($curl, CURLOPT_HEADERFUNCTION, array(&$this, 'responseHeaderCallback'));
+		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 
 		// Request types
-		switch ($this->verb) {
+		switch ($this->verb)
+		{
 			case 'GET': break;
 			case 'PUT': case 'POST': // POST only used for CloudFront
-				if ($this->fp !== false) {
+				if ($this->fp !== false)
+				{
 					curl_setopt($curl, CURLOPT_PUT, true);
 					curl_setopt($curl, CURLOPT_INFILE, $this->fp);
 					if ($this->size >= 0)
 						curl_setopt($curl, CURLOPT_INFILESIZE, $this->size);
-				} elseif ($this->data !== false) {
+				}
+				elseif ($this->data !== false)
+				{
 					curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $this->verb);
 					curl_setopt($curl, CURLOPT_POSTFIELDS, $this->data);
-					if ($this->size >= 0)
-						curl_setopt($curl, CURLOPT_BUFFERSIZE, $this->size);
-				} else
+				}
+				else
 					curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $this->verb);
 			break;
 			case 'HEAD':
@@ -1001,12 +2423,14 @@ class S3Request {
 
 		// Parse body into XML
 		if ($this->response->error === false && isset($this->response->headers['type']) &&
-		$this->response->headers['type'] == 'application/xml' && isset($this->response->body)) {
+		$this->response->headers['type'] == 'application/xml' && isset($this->response->body))
+		{
 			$this->response->body = simplexml_load_string($this->response->body);
 
 			// Grab S3 errors
-			if (!in_array($this->response->code, array(200, 204)) &&
-			isset($this->response->body->Code, $this->response->body->Message)) {
+			if (!in_array($this->response->code, array(200, 204, 206)) &&
+			isset($this->response->body->Code, $this->response->body->Message))
+			{
 				$this->response->error = array(
 					'code' => (string)$this->response->body->Code,
 					'message' => (string)$this->response->body->Message
@@ -1023,6 +2447,24 @@ class S3Request {
 		return $this->response;
 	}
 
+	/**
+	* Sort compare for meta headers
+	*
+	* @internal Used to sort x-amz meta headers
+	* @param string $a String A
+	* @param string $b String B
+	* @return integer
+	*/
+	private function sortMetaHeadersCmp($a, $b)
+	{
+		$lenA = strpos($a, ':');
+		$lenB = strpos($b, ':');
+		$minLen = min($lenA, $lenB);
+		$ncmp = strncmp($a, $b, $minLen);
+		if ($lenA == $lenB) return $ncmp;
+		if (0 == $ncmp) return $lenA < $lenB ? -1 : 1;
+		return $ncmp;
+	}
 
 	/**
 	* CURL write callback
@@ -1031,39 +2473,95 @@ class S3Request {
 	* @param string &$data Data
 	* @return integer
 	*/
-	private function _responseWriteCallback(&$curl, &$data) {
-		if ($this->response->code == 200 && $this->fp !== false)
+	private function responseWriteCallback(&$curl, &$data)
+	{
+		if (in_array($this->response->code, array(200, 206)) && $this->fp !== false)
 			return fwrite($this->fp, $data);
 		else
-			$this->response->body .= $data;
+		{
+			if (isset($this->response->body))
+				$this->response->body .= $data;
+			else
+				$this->response->body = $data;
+		}
 		return strlen($data);
+	}
+
+
+	/**
+	* Check DNS conformity
+	*
+	* @param string $bucket Bucket name
+	* @return boolean
+	*/
+	private function dnsBucketName($bucket)
+	{
+		if (strlen($bucket) > 63 || preg_match("/[^a-z0-9\.-]/", $bucket) > 0) return false;
+		if (S3::$useSSL && strstr($bucket, '.') !== false) return false;
+		if (strstr($bucket, '-.') !== false) return false;
+		if (strstr($bucket, '..') !== false) return false;
+		if (!preg_match("/^[0-9a-z]/", $bucket)) return false;
+		if (!preg_match("/[0-9a-z]$/", $bucket)) return false;
+		return true;
 	}
 
 
 	/**
 	* CURL header callback
 	*
-	* @param resource &$curl CURL resource
-	* @param string &$data Data
+	* @param resource $curl CURL resource
+	* @param string $data Data
 	* @return integer
 	*/
-	private function _responseHeaderCallback(&$curl, &$data) {
+	private function responseHeaderCallback($curl, $data)
+	{
 		if (($strlen = strlen($data)) <= 2) return $strlen;
 		if (substr($data, 0, 4) == 'HTTP')
 			$this->response->code = (int)substr($data, 9, 3);
-		else {
-			list($header, $value) = explode(': ', trim($data), 2);
-			if ($header == 'Last-Modified')
+		else
+		{
+			$data = trim($data);
+			if (strpos($data, ': ') === false) return $strlen;
+			list($header, $value) = explode(': ', $data, 2);
+			$header = strtolower($header);
+			if ($header == 'last-modified')
 				$this->response->headers['time'] = strtotime($value);
-			elseif ($header == 'Content-Length')
+			elseif ($header == 'date')
+				$this->response->headers['date'] = strtotime($value);
+			elseif ($header == 'content-length')
 				$this->response->headers['size'] = (int)$value;
-			elseif ($header == 'Content-Type')
+			elseif ($header == 'content-type')
 				$this->response->headers['type'] = $value;
-			elseif ($header == 'ETag')
+			elseif ($header == 'etag')
 				$this->response->headers['hash'] = $value{0} == '"' ? substr($value, 1, -1) : $value;
 			elseif (preg_match('/^x-amz-meta-.*$/', $header))
-				$this->response->headers[$header] = is_numeric($value) ? (int)$value : $value;
+				$this->response->headers[$header] = $value;
 		}
 		return $strlen;
+	}
+
+}
+
+/**
+ * S3 exception class
+ *
+ * @link http://undesigned.org.za/2007/10/22/amazon-s3-php-class
+ * @version 0.5.0-dev
+ */
+
+class S3Exception extends Exception {
+	/**
+	 * Class constructor
+	 *
+	 * @param string $message Exception message
+	 * @param string $file File in which exception was created
+	 * @param string $line Line number on which exception was created
+	 * @param int $code Exception code
+	 */
+	function __construct($message, $file, $line, $code = 0)
+	{
+		parent::__construct($message, $code);
+		$this->file = $file;
+		$this->line = $line;
 	}
 }

--- a/pub/css/options.css
+++ b/pub/css/options.css
@@ -43,7 +43,8 @@ input.w3tc-error, textarea.w3tc-error {
 
 
 .w3tc-status {
-    padding: 5px
+    padding: 5px;
+    line-height:2.3
 }
 
 #w3tc-help ul {

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -723,7 +723,8 @@ jQuery(function() {
                     engine: 's3',
                     'config[key]': jQuery('#cdn_s3_key').val(),
                     'config[secret]': jQuery('#cdn_s3_secret').val(),
-                    'config[bucket]': jQuery('#cdn_s3_bucket').val()
+                    'config[bucket]': jQuery('#cdn_s3_bucket').val(),
+                    'config[bucket_location]': jQuery('#cdn_s3_bucket_location').val()
                 });
 
                 if (cnames.length) {
@@ -737,6 +738,7 @@ jQuery(function() {
                     'config[key]': jQuery('#cdn_cf_key').val(),
                     'config[secret]': jQuery('#cdn_cf_secret').val(),
                     'config[bucket]': jQuery('#cdn_cf_bucket').val(),
+                    'config[bucket_location]': jQuery('#cdn_cf_bucket_location').val(),
                     'config[id]': jQuery('#cdn_cf_id').val()
                 });
 
@@ -897,6 +899,12 @@ jQuery(function() {
         status.removeClass('w3tc-error');
         status.removeClass('w3tc-success');
         status.addClass('w3tc-process');
+        
+        var status2 = jQuery('#cdn_create_container_status');
+        status2.removeClass('w3tc-error');
+        status2.removeClass('w3tc-success');
+        status2.html('');
+
         status.html('Testing...');
 
         jQuery.post('admin.php?page=w3tc_dashboard', params, function(data) {
@@ -999,6 +1007,12 @@ jQuery(function() {
         status.removeClass('w3tc-error');
         status.removeClass('w3tc-success');
         status.addClass('w3tc-process');
+
+        var status2 = jQuery('#cdn_test_status');
+        status2.removeClass('w3tc-error');
+        status2.removeClass('w3tc-success');
+        status2.html('');            
+
         status.html('Creating...');
 
         jQuery.post('admin.php?page=w3tc_dashboard', params, function(data) {

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -691,6 +691,10 @@ jQuery(function() {
       var metadata = me.metadata();
       w3tc_use_poll_zone(metadata.type, metadata.nonce);
     });
+    
+    jQuery('#cdn_s3_bucket,#cdn_cf_bucket').focusout(function () {
+      jQuery(this).val(jQuery(this).val().toLowerCase());
+    });    
 
     jQuery('#cdn_test').click(function() {
         var me = jQuery(this);


### PR DESCRIPTION
Because Amazon has moved AWS to signature version 4 (v4) it left W3TC incapable of authenticating AWS requests to v4 regions and endpoints.  At the time of this writing there are six _Version 4 Only_ regions.  And Amazon has made it clear that all new regions and endpoints created in the future will only be for v4.  

Prior to this update when one made a request to "v4 only" regions in W3TC you got an AWS4-HMAC-SHA256 error message.  AWS4-HMAC-SHA256 is the signing algorithm for the v4 signature.  This would have been a problem if the user had created a bucket outside W3TC (e.g., on the AWS website) that used a "v4 only" region and provided the bucket name in W3TC.

With this update the underlying CDN engine now supports signature version 4.  It also maintains backwards compatibility to all version 2 regions so the user does not need to make any changes -- it will use v4 when it needs to.

Interestingly, I noticed that W3TC only made available four selectable regions when creating a bucket.  I assume it was because this list had not been updated for a very long time.  And so, in this update I've also gone ahead and revised this list to include all available regions (14 in total, as of this writing).

### Design Layout Note

I had to slightly modify how the _Create Bucket_ button (of _Amazon Simple Storage Service: S3 - Origin Push_) and the _Create Bucket & Distribution_ button (of _Amazon CloudFront - Origin Push_) operated.  Prior to this update these buttons would bring up a popup modal window allowing the user to select a bucket location/region before creating the bucket.  After the bucket was generated the selected region associated with that bucket was never shown again to the user.  That was fine for version 2 regions but with v4 a new problem emerged.

Because the v4 signature demands that an existing bucket name also include its associating bucket region for all AWS requests it is now imperative that the region always be shown on the same page as the bucket name so that those who create a "v4 only" bucket outside W3TC can now provide their selected region within W3TC.  If they aren't able to provide that associated region, as was the case previously, all communication will fail.  As such, the region drop-down list box was moved and placed alongside the bucket name. Please see the **attached image** below to get a better idea what i am talking about. 

Current W3TC users of AWS, prior to this update, will not be affected by this change in any way.  The drop-down box will simply show the words _Select Bucket Location_, while under the hood it will be using the version 2 signature for all AWS communications -- just like before. :octocat: 

![aws](https://cloud.githubusercontent.com/assets/5191497/22405206/10c1109c-e60d-11e6-92f3-4218e4013817.png)