### PR TITLE
Save Cloudflare Settings - SSL Update Failure

### DIFF
--- a/Extension_CloudFlare_Page_View.php
+++ b/Extension_CloudFlare_Page_View.php
@@ -116,8 +116,7 @@ CloudFlare not available: <?php echo $error_message; ?>
 				'label' => __( 'Cache time:', 'w3-total-cache' ),
 				'control' => 'textbox',
 				'description' =>
-				'How many minutes data retrieved from CloudFlare:' .
-				'should be stored. Minimum is 1 minute.'
+				'How many minutes data retrieved from CloudFlare should be stored. Minimum is 1 minute.'
 			)
 		);
 

--- a/Extension_CloudFlare_SettingsForUi.php
+++ b/Extension_CloudFlare_SettingsForUi.php
@@ -90,7 +90,7 @@ class Extension_CloudFlare_SettingsForUi {
 
 			// convert checkbox value to on/off
 			// excetion: rocket loader is not checkbox so contains real value
-			if ( $settings_key != 'rocket_loader' ) {
+			if ( $settings_key != 'rocket_loader' && $settings_key != 'ssl' ) {
 				if ( $current_value == 'on' || $current_value == 'off' ) {
 					// it's boolean, so control is checkbox - convert it
 					$value = ( $value == '0' ? 'off' : 'on' );


### PR DESCRIPTION
After clicking the _Save Cloudflare Settings_ button within the CloudFlare settings' extensions page a _**Failed to update option ssl: Invalid value for zone setting, ssl**_ alert message is seen (see the attached image).  This error seems to occur consistently when the SSL drop-down box is modified to _**Off**_.

### Why The Problem Occurs
This error occurs because the words: _on_ and _off_ are special indicators to W3TC when dealing with checkbox values.  Because the SSL drop-down list box is not a checkbox and in fact uses the keyword _off_, W3TC was mistakenly confusing it as a checkbox and, thus, setting the final SSL value as the word: _on_.  

But why _on_?  Well, it does this because since it mistakenly assumed it was dealing with a checkbox it figured the value had to be an integer.  But since the value: _off_, which the SSL drop-down sent to W3TC, is not an integer it defaulted to setting the final value, which is sent to Cloudflare, as the word: _on_.  Now, because  Cloudflare doesn't understand the word _on_, under the context for setting the SSL, it returned back a failure response. :octocat: 

[![Immagine.jpg](https://s28.postimg.org/u3azglvrh/Immagine.jpg)](https://postimg.org/image/nplwdcqvd/)