### PR TITLE
Malformed HTML in Generated Item UIs (Admin Pages)

### DIFF
--- a/Util_Ui.php
+++ b/Util_Ui.php
@@ -531,7 +531,7 @@ class Util_Ui {
 		$a = apply_filters( 'w3tc_ui_settings_item', $a );
 
 		if ( isset( $a['style'] ) ) {
-			echo '<tr><th colspan="2"';
+			echo '<tr><th colspan="2">';
 		} else {
 			echo '<tr><th';
 


### PR DESCRIPTION
When using the `Util_Ui::config_item` function and setting it's _style_ attribute to **2** (this tells it to span two columns for its container table header), it causes the HTML to be malformed, resulting in the generated `<label>` tag to be inserted incorrectly, potentially destroying the page layout in less popular (or older) browsers, which might even include Internet Explorer.  This fix resolves the problem and the page validates correctly. :octocat: 

For those reading and curious what the problem looks like, here is a snapshot -- note the red area:

![https_0ssd_com_wp-admin_admin_php_page_w3tc_browsercache_-_2017-02-02_02_10_05](https://cloud.githubusercontent.com/assets/5191497/22540232/02de6834-e8ed-11e6-8541-b136397e34ac.png)
