### PR TITLE
W3TC is Collecting Tracking Usage At All Times

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -1887,7 +1887,7 @@ $keys = array(
 	),
 	'common.track_usage' => array(
 		'type' => 'boolean',
-		'default' => true
+		'default' => false
 	),
 	'common.tweeted' => array(
 		'type' => 'boolean',

--- a/Generic_AdminActions_Config.php
+++ b/Generic_AdminActions_Config.php
@@ -193,8 +193,11 @@ class Generic_AdminActions_Config {
 		$track_usage = Util_Request::get_boolean( 'track_usage' );
 		$this->_config->set( 'common.support', $support );
 		$this->_config->set( 'common.tweeted', $tweeted );
+
 		if ( $track_usage )
 			$this->_config->set( 'common.track_usage', true );
+		else
+			$this->_config->set( 'common.track_usage', false );
 
 		if ( $signmeup ) {
 			if ( Util_Environment::is_w3tc_enterprise( $this->_config ) )

--- a/Generic_AdminActions_EdgeMode.php
+++ b/Generic_AdminActions_EdgeMode.php
@@ -21,6 +21,7 @@ class Generic_AdminActions_EdgeMode {
 
 	public function w3tc_edge_mode_disable() {
 		$this->_config->set( 'common.edge', false );
+		$this->_config->set( 'common.track_usage', false );
 		$this->_config->save();
 
 		Util_Admin::redirect( array( 'w3tc_note' => 'disabled_edge' ) );

--- a/Generic_GeneralPage_View_ShowEdge.js
+++ b/Generic_GeneralPage_View_ShowEdge.js
@@ -4,8 +4,8 @@ jQuery(function() {
         id:'w3tc-overlay',
         close: '',
         width: 800,
-        height: 210,
-        url: ajaxurl + '?action=w3tc_ajax&_wpnonce=' + w3tc_nonce + 
+        height: 240,
+        url: ajaxurl + '?action=w3tc_ajax&_wpnonce=' + w3tc_nonce +
             '&w3tc_action=generic_edge'
     });
 });

--- a/Generic_GeneralPage_View_ShowSupportUs.js
+++ b/Generic_GeneralPage_View_ShowSupportUs.js
@@ -4,7 +4,10 @@ jQuery(function() {
         close: '',
         width: 800,
         height: 445,
-        url: ajaxurl + '?action=w3tc_ajax&_wpnonce=' + w3tc_nonce + 
-            '&w3tc_action=generic_support_us'
+        url: ajaxurl + '?action=w3tc_ajax&_wpnonce=' + w3tc_nonce +
+            '&w3tc_action=generic_support_us',
+        callback: function(lightbox) {
+            jQuery(".palette-twitter").click(function() {jQuery("#tweeted").val("1");});
+        }
     });
 });

--- a/inc/lightbox/edge.php
+++ b/inc/lightbox/edge.php
@@ -12,6 +12,7 @@ if ( !defined( 'W3TC' ) )
     <div class="content">
     <p><strong><?php _e( 'Enable "Edge Mode" to opt-in to pre-release features or simply close this window to continue to enjoy bug fixes, security fixes and stable updates only.', 'w3-total-cache' ) ?></strong></p>
     <p><?php _e( 'We want to ensure that those who are interested in ongoing performance optimizations always have access to the latest functionality and optimization techniques. Those who enable edge mode should have experience in troubleshooting WordPress installations.', 'w3-total-cache' ) ?></p>
+    <p><?php _e( 'Please be aware that by enabling "Edge Mode" you are also accepting to send <strong><u>anonymous tracking usage</u></strong>.', 'w3-total-cache' ) ?></p>
     </div>
     <div class="w3tc_overlay_footer">
         <?php

--- a/inc/lightbox/support_us.php
+++ b/inc/lightbox/support_us.php
@@ -62,7 +62,11 @@ echo Util_Ui::action_button(
 	__( 'Tell Your Friends', 'w3-total-cache' ),
 	$tweet_url,
 	"btn w3tc-size image btn-default palette-twitter",
-	true ) ?>
+	true );
+echo Util_Ui::hidden(
+	__( 'tweeted' ),
+	__( 'tweeted' ),
+	'0' ) ?>
                     </label>
                 </li>
                 <li>


### PR DESCRIPTION
At present the official W3TC is in violation of WP's [Plugin Guidelines](https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/).  W3TC is phoning home the tracking usage data about its users at all times without informing its users.  This includes doing so immediately upon first activation.  Although its "support us" page does pop up once every 30 days and gives the user the option to opt-out of tracking usage, the user's choice to not be tracked is ignored and the tracking continues to happen behind the scenes.

This fix corrects several problems:

1. It modifies the default option: **_common.track_usage_** from **true** to **false**.  When user's install W3TC for the first time this variable's value of _true_ indicates that it should begin tracking right away, which is wrong.

2. When the user selects to opt-out of tracking (from the "support us" popup) this fix now correctly stores the user's choice to the configuration file instead of ignoring it.

3. When the user clicks the "_Tweet_" button (aka "_Tell Your Friends_") it's suppose to set a post variable called **tweeted** and pass this information back for processing.  This never happens when the user clicks the tweet button.  This fix now corrects this by including the missing javascript logic to monitor the user clicking the tweet button so that the _tweeted_ variable gets set correctly, and when passed back the _**common.tweeted**_  variable now can be assigned appropriately, instead of storing _false_ at all times (despite the tweet click), and saved into the user's configuration file.

4. The "_Edge Mode_" popup does not inform the user that when enabled it phone's home tracking usage data.  I added a line alerting the user of this fact so they aren't being misled.  It should also be noted that when Edge Mode does get disabled by the user this fix now also turns off tracking since the act of disabling edge mode logically is an indication that the user is opting out of being tracked as well. Here is a snapshot of the new line on the Edge Mode popup:

![edge-track](https://cloud.githubusercontent.com/assets/5191497/22569522/d7a3f890-e965-11e6-8a68-8d6bebda36d3.png)

:octocat: 