### PR TITLE
Checkbox to Use CDN URLs for Media Library on Admin Pages

### DIFF
--- a/Cdn_ConfigLabels.php
+++ b/Cdn_ConfigLabels.php
@@ -16,6 +16,7 @@ class Cdn_ConfigLabels {
 				'cdn.import.external' => __( 'Import external media library attachments', 'w3-total-cache' ),
 				'cdn.canonical_header' => __( 'Add canonical header', 'w3-total-cache' ),
 				'cdn.reject.ssl' => __( 'Disable <acronym title="Content Delivery Network">CDN</acronym> on <acronym title="Secure Sockets Layer">SSL</acronym> pages', 'w3-total-cache' ),
+				'cdn.admin.media_library' => __( 'Use CDN links for the Media Library on admin pages', 'w3-total-cache' ),
 				'cdn.reject.logged_roles' => __( 'Disable <acronym title="Content Delivery Network">CDN</acronym> for the following roles', 'w3-total-cache' ),
 				'cdn.reject.uri' => __( 'Disable <acronym title="Content Delivery Network">CDN</acronym> on the following pages:', 'w3-total-cache' ),
 				'cdn.autoupload.enabled' => __( 'Export changed files automatically', 'w3-total-cache' ),

--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -765,28 +765,27 @@ class Cdn_Plugin {
     function w3tc_attachment_url( $url ) {
         static $allowed_files = null;
 
-		if ( $this->_config->get_boolean( 'cdn.reject.logged_roles' ) && !$this->_check_logged_in_role_allowed() ) {
-            return $url;
-        }
+		if ( ( defined( 'WP_ADMIN' ) && $this->_config->get_boolean( 'cdn.admin.media_library' ) ) ||
+			 ( $this->can_cdn() && $this->can_cdn2( $empty ) ) ) {
+			$url = trim( $url );
 
-        $url = trim( $url );
+			if ( !empty( $url ) ) {
+				if ( empty( $allowed_files ) ) {
+					$allowed_files = $this->get_files();
+				}
 
-        if ( !empty( $url ) ) {
-            if ( empty( $allowed_files ) ) {
-                $allowed_files = $this->get_files();
-            }
+				$parsed = parse_url( $url );
+				$rel_url = ( isset( $parsed['path'] ) ? $parsed['path'] : '/' ) .
+						   ( isset( $parsed['query'] ) ? '?' . $parsed['query'] : '' );
 
-            $parsed = parse_url( $url );
-            $rel_url = ( isset( $parsed['path'] ) ? $parsed['path'] : '/' ) .
-                       ( isset( $parsed['query'] ) ? '?' . $parsed['query'] : '' );
-
-            if ( in_array( ltrim( $rel_url, '/' ), $allowed_files ) ) {
-                $common = Dispatcher::component( 'Cdn_Core' );
-                $cdn = $common->get_cdn();
-                $remote_path = $common->uri_to_cdn_uri( $rel_url );
-                $url = $cdn->_format_url( $remote_path );
-            }
-        }
+				if ( in_array( ltrim( $rel_url, '/' ), $allowed_files ) ) {
+					$common = Dispatcher::component( 'Cdn_Core' );
+					$cdn = $common->get_cdn();
+					$remote_path = $common->uri_to_cdn_uri( $rel_url );
+					$url = $cdn->_format_url( $remote_path );
+				}
+			}
+		}
 
         return $url;
     }		

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -1410,6 +1410,10 @@ $keys = array(
 		'type' => 'boolean',
 		'default' => false
 	),
+	'cdn.admin.media_library' => array(
+		'type' => 'boolean',
+		'default' => false
+	),
 	'varnish.configuration_overloaded' => array(
 		'type' => 'boolean',
 		'default' => false

--- a/inc/options/cdn.php
+++ b/inc/options/cdn.php
@@ -181,6 +181,12 @@ if ( $cdn_engine == 'google_drive' || $cdn_engine == 'highwinds' ||
 			</tr>
 			<tr>
 				<th colspan="2">
+					<?php $this->checkbox( 'cdn.admin.media_library' ) ?> <?php Util_Ui::e_config_label( 'cdn.admin.media_library' ) ?></label><br />
+					<span class="description">All Media Library content will use CDN links on administration pages.</span>
+				</th>
+			</tr>
+			<tr>
+				<th colspan="2">
 					<?php $this->checkbox( 'cdn.reject.logged_roles' ) ?> <?php Util_Ui::e_config_label( 'cdn.reject.logged_roles' ) ?></label><br />
 					<span class="description"><?php _e( 'Select user roles that will use the origin server exclusively:', 'w3-total-cache' ) ?></span>
 


### PR DESCRIPTION
This is a complete rewrite of #336 (so it's not dependent on that PR) that moves away from using the `wp_prepare_attachment_for_js()` filter and attaches to `wp_get_attachment_url` and `attachment_link` filters instead.  It also includes a new checkbox allowing the user to specify if they want to use CDN links instead of local ones for Media Library content on admin pages.

The new checkbox is located within the _CDN_ page under _Advanced_ and looks like this:

![cdn](https://cloud.githubusercontent.com/assets/5191497/22574184/54471386-e97b-11e6-8917-ca6eb31a0a97.png)
