### PR TITLE
Additional Home URLs (of Page Cache) not Purging

### DIFF
--- a/Util_PageUrls.php
+++ b/Util_PageUrls.php
@@ -756,8 +756,9 @@ class Util_PageUrls {
 				continue;
 
 			foreach ( $home_urls as $home ) {
+				$home = trim( $home );
 				if ( !empty( $home ) ) {
-					$mirror_url = $home . substr( $url, strlen( $url_prefix ) );
+					$mirror_url = trailingslashit( $home ) . substr( $url, strlen( $url_prefix ) );
 					$queued_urls[$mirror_url] = '*';
 				}
 			}


### PR DESCRIPTION
When working correctly the _Additional Home URLs_ field under _Page Cache_ will purge content for mirrored domains.  However, prior to this bug fix it didn't working correctly.  It only purged from the domain that it was currently processing from.

## Why the Problem Occurs
When constructing the mirror URL for purging, the code forgot to check to make sure that the user had provided a trailing slash for these additional home URLs.  Because it neither checked nor added a trailing slash, the user's additional non-trailing slashed home URLs were being concatenated with the non-leading slashed paths, resulting in final URLs that were malformed &ndash; no purge for these additional URLs. :octocat: 