### PR TITLE
[0.9.4.x] Save Settings Strips Backslash

### DIFF
--- a/lib/W3/Request.php
+++ b/lib/W3/Request.php
@@ -131,7 +131,7 @@ class W3_Request {
      */
     static function get_request() {
 
-    	if( !isset(self::$request) ){
+    	if( !isset(self::$request) || current_filter() === 'init' ){
 	        if (!isset($_GET)) {
 	            $_GET = array();
 	        }


### PR DESCRIPTION
This was a bug that stripped out a single backslash for every pair in user input prior to saving the settings.  This would typically be a problem if using it in regex.  So, for example, something like _`sitemap\.xml`_ would have been saved as _`sitemap.xml`_, while _`sitemap\\.xml`_ would have been saved as _`sitemap\.xml`_

The problem was due to a previous optimization.  The optimization dramatically reduces the amount of time that php has to generate a new array.  What wasn't known until now is that some function earlier in the chain modifies the $_POST content which adds double-slashes prior to saving the settings.  It is triggered by the `init` action.  Since the optimization was unaware of this it saved the user data without the modification, thus, appearing to strip out the backslashes.

This fix resolves the problem.