### PR TITLE
Configuration Bug -- Redis/Memcached Server Entries

### DIFF
--- a/Generic_AdminActions_Default.php
+++ b/Generic_AdminActions_Default.php
@@ -740,7 +740,7 @@ class Generic_AdminActions_Default {
 				array_map( 'stripslashes_deep', $request_value );
 			else
 				$request_value = stripslashes( $request_value );
-			if ( strpos( $request_key, 'memcached_servers' ) )
+			if ( strpos( $request_key, 'memcached__servers' ) || strpos( $request_key, 'redis__servers' ) )
 				$request_value = explode( ',', $request_value );
 
 			$key = Util_Ui::config_key_from_http_name( $request_key );


### PR DESCRIPTION
This is a fix for the issue described in #366, where configuration values for comma-separated lists of Redis or Memcached servers get incorrectly saved as a string instead of an array.