### PR TITLE
Undefined Variable: "is_amp_endpoint"

### DIFF
--- a/Extension_Amp_Plugin.php
+++ b/Extension_Amp_Plugin.php
@@ -19,11 +19,12 @@ class Extension_Amp_Plugin {
 
 
 	private function is_amp_endpoint() {
-		if ( is_null( $is_amp_endpoint ) && function_exists('is_amp_endpoint') ) {
-			$is_amp_endpoint = is_amp_endpoint();
+		
+		if ( function_exists('is_amp_endpoint') ) {
+			return is_amp_endpoint();
 		}
 
-		return $is_amp_endpoint;
+		return null;
 	}
 
 

--- a/Extension_Amp_Plugin.php
+++ b/Extension_Amp_Plugin.php
@@ -3,7 +3,7 @@ namespace W3TC;
 
 class Extension_Amp_Plugin {
 	function __construct() {
-		$is_amp_endpoint = null;
+
 	}
 
 	public function run() {


### PR DESCRIPTION
> PHP Notice:  Undefined variable: is_amp_endpoint in \wp-content\plugins\w3-total-cache\Extension_Amp_Plugin.php on line 22

`is_amp_endpoint` check if an undefined variable `$is_amp_endpoint` is `null`

```php
private function is_amp_endpoint() {
    if ( is_null( $is_amp_endpoint ) && function_exists('is_amp_endpoint') ) {
        $is_amp_endpoint = is_amp_endpoint();
    }

    return $is_amp_endpoint;
}
```

the fix is return the value of is_amp_endpoint if the function exists

```php
private function is_amp_endpoint() {
		
    if ( function_exists('is_amp_endpoint') ) {
        return is_amp_endpoint();
    }

    return null;
}
```
