### PR TITLE
[v0.9.4.x] - Session Cookies (Security Headers)

### DIFF
--- a/lib/W3/BrowserCacheAdminEnvironment.php
+++ b/lib/W3/BrowserCacheAdminEnvironment.php
@@ -328,17 +328,6 @@ class W3_BrowserCacheAdminEnvironment {
             $rules .= $this->_rules_cache_generate_apache_for_type($config, 
                 $extensions, $type);
 
-        $sec = "    php_flag session.cookie_httponly " . ( $config->get_boolean( 'browsercache.security.session.cookie_httponly' ) ? "on" : "off" ) . "\n" .
-               "    php_flag session.cookie_secure " . ( $config->get_boolean( 'browsercache.security.session.cookie_secure' ) ? "on" : "off" ) . "\n" .
-               "    php_flag session.use_only_cookies " . ( $config->get_boolean( 'browsercache.security.session.use_only_cookies' ) ? "on" : "off" ) . "\n</ifModule>\n";
-
-        $rules .= "<IfModule mod_php5.c>\n";
-        $rules .= $sec;
-        $rules .= "<IfModule mod_php7.c>\n";
-        $rules .= $sec;
-        $rules .= "<IfModule mod_suphp.c>\n";
-        $rules .= $sec;
-
         if ( $config->get_boolean( 'browsercache.security.hsts' ) ||
              $config->get_boolean( 'browsercache.security.xfo' )  ||
              $config->get_boolean( 'browsercache.security.xss' )  ||
@@ -593,10 +582,6 @@ class W3_BrowserCacheAdminEnvironment {
         foreach ($mime_types as $type => $extensions)
             $this->_rules_cache_generate_nginx_for_type($config, $rules, 
                 $extensions, $type);
-
-        $rules .= "fastcgi_param PHP_FLAG \"session.cookie_httponly=" . ( $config->get_boolean( 'browsercache.security.session.cookie_httponly' ) ? "on" : "off" ) . "\n" .
-        "session.cookie_secure=" . ( $config->get_boolean( 'browsercache.security.session.cookie_secure' ) ? "on" : "off" ) . "\n" .
-        "session.use_only_cookies=" . ( $config->get_boolean( 'browsercache.security.session.use_only_cookies' ) ? "on" : "off" ) . "\";";
 
         if ( $config->get_boolean( 'browsercache.security.hsts' ) ||
              $config->get_boolean( 'browsercache.security.xfo' )  ||

--- a/lib/W3/Plugin/BrowserCache.php
+++ b/lib/W3/Plugin/BrowserCache.php
@@ -40,6 +40,10 @@ class W3_Plugin_BrowserCache extends W3_Plugin {
                 'w3tc_cdn_url')
                 ,0, 2);
         }
+
+        @ini_set( 'session.use_only_cookies', $this->_config->get_boolean( 'browsercache.security.session.use_only_cookies' ) ? '1' : '0' );
+        @ini_set( 'session.cookie_httponly', $this->_config->get_boolean( 'browsercache.security.session.cookie_httponly' ) ? '1' : '0' );
+        @ini_set( 'session.cookie_secure', $this->_config->get_boolean( 'browsercache.security.session.cookie_secure' ) ? '1' : '0' );
     }
 
     /**


### PR DESCRIPTION
This is a fix for session cookie security handling for the v0.9.4.x generation.

The previous code was using the .htaccess (or nginx.conf) file to set those security options. But because each user's environment is different there isn't an assurance of the needed privileges to modify php values from said files.

As such, this management was shifted to be handled in code entirely, which is a better approach. It slipped my mind that session cookies are generated in php during a non-cached session. My original, and mistaken, oversight was that i needed to continually have these session cookie security settings always configured (via the htaccess/nginx.conf) even during cached page servings, which isn't true. Those settings are important only when the session is generated -- during a non-cached period. So this fix resolves that.