### PR TITLE
Page Cache - "Accepted Query Strings" Enhancement

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1757,28 +1757,15 @@ class PgCache_ContentGrabber {
             $val .=  ( strpos( $val, '=' ) === false ? '.*?' : '' );
         }
 
-        $pass=false;
+		$accept_qs = implode( '|', $accept_qs );
 
         foreach ( $_GET as $key => $value ) {
-            $match = false;
-            foreach ( $accept_qs as $qs ) {
-                if ( @preg_match( '~^' . $qs . '$~i', $key . "=$value" ) ) {
-                    $match=true;
-                    $pass=true;
-                    break;
-                }
-            }
-
-            if ( !$match ) {
-            	return false;
+			if ( !@preg_match( '~^(' . $accept_qs . ')$~i', $key . "=$value" ) ) {
+				return false;
             }
         }
 
-        if ( $pass ) {
-        	return true;
-        }
-
-        return false;
+        return true;
     }
 
 	/**

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1750,18 +1750,18 @@ class PgCache_ContentGrabber {
 	 */
     private function _check_query_string() {
         $accept_qs = $this->_config->get_array( 'pgcache.accept.qs' );
-		$accept_qs = array_filter( $accept_qs, function( $val ) { return $val != ""; } );
+        $accept_qs = array_filter( $accept_qs, function( $val ) { return $val != ""; } );
 
         foreach ( $accept_qs as &$val ) {
             $val = preg_quote( trim( str_replace( "+", " ", $val ) ), "~" );
             $val .=  ( strpos( $val, '=' ) === false ? '.*?' : '' );
         }
 
-		$accept_qs = implode( '|', $accept_qs );
+        $accept_qs = implode( '|', $accept_qs );
 
         foreach ( $_GET as $key => $value ) {
-			if ( !@preg_match( '~^(' . $accept_qs . ')$~i', $key . "=$value" ) ) {
-				return false;
+            if ( !@preg_match( '~^(' . $accept_qs . ')$~i', $key . "=$value" ) ) {
+                return false;
             }
         }
 

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1743,13 +1743,18 @@ class PgCache_ContentGrabber {
 		return in_array( $content_type, $cache_headers );
 	}
 
+	/**
+	 * Check whether requested page has query string(s) that can be cached
+	 *
+	 * @return bool
+	 */
     private function _check_query_string() {
         $accept_qs = $this->_config->get_array( 'pgcache.accept.qs' );
-
 		$accept_qs = array_filter( $accept_qs, function( $val ) { return $val != ""; } );
 
         foreach ( $accept_qs as &$val ) {
-        	$val = preg_quote( trim( str_replace( "+", " ", $val ) ), "~" );
+            $val = preg_quote( trim( str_replace( "+", " ", $val ) ), "~" );
+            $val .=  ( strpos( $val, '=' ) === false ? '.*?' : '' );
         }
 
         $pass=false;
@@ -1757,8 +1762,6 @@ class PgCache_ContentGrabber {
         foreach ( $_GET as $key => $value ) {
             $match = false;
             foreach ( $accept_qs as $qs ) {
-                $qs .=  ( strpos( $qs, '=' ) === false ? '.*?' : '' );
-
                 if ( @preg_match( '~^' . $qs . '$~i', $key . "=$value" ) ) {
                     $match=true;
                     $pass=true;
@@ -1766,12 +1769,12 @@ class PgCache_ContentGrabber {
                 }
             }
 
-            if (!$match) {
+            if ( !$match ) {
             	return false;
             }
         }
 
-        if ($pass) {
+        if ( $pass ) {
         	return true;
         }
 

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -592,6 +592,28 @@ class PgCache_Environment {
 			$rules .= "    RewriteRule ^(.*\\/)?w3tc_rewrite_test([0-9]+)/?$ $1?w3tc_rewrite_test=1 [L]\n";
 		}
 
+        /**
+         * Set accept query strings
+         */
+        $w3tc_query_strings = array_filter( $config->get_array( 'pgcache.accept.qs' ), function( $val ) { return $val != ""; } );
+
+        if ( !empty( $w3tc_query_strings ) ) {
+            foreach ( $w3tc_query_strings as &$val ) {
+                $val = trim( str_replace( " ", "\+", preg_quote( $val ) ) );
+            }
+
+            $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%{QUERY_STRING}]\n";
+
+            foreach ( $w3tc_query_strings as $query ) {
+                $query .=  ( strpos( $query, '=' ) === false ? '.*?' : '' );
+                $rules .= "    RewriteCond %{ENV:W3TC_QUERY_STRING} ^(.*?&|)".$query."(&.*|)$ [NC]\n";
+                $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%1%2]\n";
+            }
+
+            $rules .= "    RewriteCond %{ENV:W3TC_QUERY_STRING} ^&+$\n";
+            $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING]\n";
+        }
+
 		/**
 		 * Check for mobile redirect
 		 */
@@ -697,10 +719,11 @@ class PgCache_Environment {
 		 */
 		$use_cache_rules .= "    RewriteCond %{REQUEST_METHOD} !=POST\n";
 
-		/**
-		 * Query string should be empty
-		 */
-		$use_cache_rules .= "    RewriteCond %{QUERY_STRING} =\"\"\n";
+        /**
+         * Query string should be empty
+         */
+        $use_cache_rules .= empty( $w3tc_query_strings ) ? "    RewriteCond %{QUERY_STRING} =\"\"\n" :
+                                                           "    RewriteCond %{ENV:W3TC_QUERY_STRING} =\"\"\n";
 
 		/**
 		 * Check permalink structure trailing slash
@@ -818,6 +841,30 @@ class PgCache_Environment {
 			$rules .= "rewrite ^(.*\\/)?w3tc_rewrite_test([0-9]+)/?$ $1?w3tc_rewrite_test=1 last;\n";
 		}
 
+        /**
+         * Set accept query strings
+         */
+        $w3tc_query_strings = array_filter( $config->get_array( 'pgcache.accept.qs' ), function( $val ) { return $val != ""; } );
+		
+        if ( !empty( $w3tc_query_strings ) ) {
+            foreach ( $w3tc_query_strings as &$val ) {
+                $val = trim( str_replace( " ", "\+", preg_quote( $val ) ) );
+            }
+
+            $rules .= "set \$w3tc_query_string \$query_string;\n";
+
+            foreach ( $w3tc_query_strings as $query ) {
+                $query .=  ( strpos( $query, '=' ) === false ? '.*?' : '' );
+                $rules .= "if (\$w3tc_query_string ~* \"^(.*?&|)".$query."(&.*|)$\") {\n";
+                $rules .= "    set \$w3tc_query_string $1$2;\n";
+                $rules .= "}\n";
+            }
+
+            $rules .= "if (\$w3tc_query_string ~ ^&+$) {\n";
+            $rules .= "    set \$w3tc_query_string \"\";\n";
+            $rules .= "}\n";
+        }
+
 		/**
 		 * Check for mobile redirect
 		 */
@@ -873,12 +920,12 @@ class PgCache_Environment {
 		$rules .= "    set \$w3tc_rewrite 0;\n";
 		$rules .= "}\n";
 
-		/**
-		 * Query string should be empty
-		 */
-		$rules .= "if (\$query_string != \"\") {\n";
-		$rules .= "    set \$w3tc_rewrite 0;\n";
-		$rules .= "}\n";
+        /**
+         * Query string should be empty
+         */
+        $rules .= "if (".( empty( $w3tc_query_strings ) ? "\$query_string" : "\$w3tc_query_string" ) . " != \"\") {\n";
+        $rules .= "    set \$w3tc_rewrite 0;\n";
+        $rules .= "}\n";
 
 		/**
 		 * Check permalink structure trailing slash

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -592,26 +592,26 @@ class PgCache_Environment {
 			$rules .= "    RewriteRule ^(.*\\/)?w3tc_rewrite_test([0-9]+)/?$ $1?w3tc_rewrite_test=1 [L]\n";
 		}
 
-        /**
-         * Set accept query strings
-         */
-        $w3tc_query_strings = array_filter( $config->get_array( 'pgcache.accept.qs' ), function( $val ) { return $val != ""; } );
+       /**
+        * Set accept query strings
+        */
+       $w3tc_query_strings = array_filter( $config->get_array( 'pgcache.accept.qs' ), function( $val ) { return $val != ""; } );
 
-        if ( !empty( $w3tc_query_strings ) ) {
-            foreach ( $w3tc_query_strings as &$val ) {
-                $val = trim( str_replace( " ", "\+", preg_quote( $val ) ) );
-            }
+       if ( !empty( $w3tc_query_strings ) ) {
+           foreach ( $w3tc_query_strings as &$val ) {
+               $val = trim( str_replace( " ", "\+", preg_quote( $val ) ) );
+           }
 
-            $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%{QUERY_STRING}]\n";
+           $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%{QUERY_STRING}]\n";
 
-            foreach ( $w3tc_query_strings as $query ) {
-                $query .=  ( strpos( $query, '=' ) === false ? '.*?' : '' );
-                $rules .= "    RewriteCond %{ENV:W3TC_QUERY_STRING} ^(.*?&|)".$query."(&.*|)$ [NC]\n";
-                $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%1%2]\n";
-            }
+           foreach ( $w3tc_query_strings as $query ) {
+               $query .=  ( strpos( $query, '=' ) === false ? '.*?' : '' );
+               $rules .= "    RewriteCond %{ENV:W3TC_QUERY_STRING} ^(.*?&|)".$query."(&.*|)$ [NC]\n";
+               $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%1%2]\n";
+           }
 
-            $rules .= "    RewriteCond %{ENV:W3TC_QUERY_STRING} ^&+$\n";
-            $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING]\n";
+           $rules .= "    RewriteCond %{ENV:W3TC_QUERY_STRING} ^&+$\n";
+           $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING]\n";
         }
 
 		/**
@@ -845,7 +845,7 @@ class PgCache_Environment {
          * Set accept query strings
          */
         $w3tc_query_strings = array_filter( $config->get_array( 'pgcache.accept.qs' ), function( $val ) { return $val != ""; } );
-		
+
         if ( !empty( $w3tc_query_strings ) ) {
             foreach ( $w3tc_query_strings as &$val ) {
                 $val = trim( str_replace( " ", "\+", preg_quote( $val ) ) );

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -336,7 +336,7 @@ if ( $this->_config->get_string( 'pgcache.engine' ) == 'memcached' ) {
 					<textarea id="pgcache_accept_qs" name="pgcache__accept__qs"
 						<?php Util_Ui::sealing_disabled( 'pgcache.' ) ?>
 							  cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'pgcache.accept.qs' ) ) ); ?></textarea><br />
-					<span class="description"><?php _e( 'Always cache <acronym title="Uniform Resource Locator">URL</acronym>s with these query strings.', 'w3-total-cache' ); ?></span>
+					<span class="description"><?php _e( 'Always cache <acronym title="Uniform Resource Locator">URL</acronym>s that use these query string name-value pairs. The value part is not required. But if used, separate name-value pairs with an equals sign (i.e., name=value). Each pair should be on their own line.', 'w3-total-cache' ); ?></span>
 				</td>
 			</tr>
 			<tr>
@@ -404,7 +404,7 @@ echo sprintf(
                     <textarea id="pgcache_reject_custom" name="pgcache__reject__custom" 
                         <?php Util_Ui::sealing_disabled( 'pgcache' ) ?>
                         cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array('pgcache.reject.custom' ) ) ); ?></textarea><br />
-                    <span class="description"><?php _e( 'Always ignore all pages filed under the specified custom fields. Separate name/value pairs with an equals sign (i.e., name=value).', 'w3-total-cache' ); ?></span>
+                    <span class="description"><?php _e( 'Always ignore all pages filed under the specified custom fields. Separate name-value pairs with an equals sign (i.e., name=value).', 'w3-total-cache' ); ?></span>
                 </td>
             </tr>
 			<tr>


### PR DESCRIPTION
Page Cache's _Accepted Query Strings_ box has always felt limited.  Query strings are composed of a series of field-value pairs.  Up to this point W3TC's _Accepted Query Strings_ box only analyzed field names and completely ignored their associating values.  It also was not as efficient as it could have been when _Disk: Enhanced_ mode was used.

This update hopefully improves the experience by offering two new enhancements:

* It allows the user to provide (optionally) a value, in the form: `name=value`.  Acceptable example entries could be: `utm_source=Newsletter`, `utm_medium=`, `utm_campaign`

* If _Disk: Enhanced_ is enabled it leverages the user's htaccess (or nginx.conf) file to determine if the requesting query string URL contains only one or more acceptable query string name-value pairs.  If it does then the request page proceeds to being cached or served a cached page.  Prior to this, all query string URLs, regardless of the page cache disk mode used, would need to boot up the W3TC backend for processing.  Performance-wise, it was not the ideal workflow.

:octocat: 
