### PR TITLE
Incorrect Use of Removing Query String From URLs

### DIFF
--- a/DbCache_Environment.php
+++ b/DbCache_Environment.php
@@ -114,7 +114,7 @@ class DbCache_Environment {
 					if ( isset( $_GET['page'] ) )
 						$url = 'admin.php?page=' . $_GET['page'] . '&amp;';
 					else
-						$url = basename( Util_Environment::remove_query( $_SERVER['REQUEST_URI'] ) ) . '?page=w3tc_dashboard&amp;';
+						$url = basename( Util_Environment::remove_query_all( $_SERVER['REQUEST_URI'] ) ) . '?page=w3tc_dashboard&amp;';
 					$remove_url = Util_Ui::admin_url( $url . 'w3tc_default_remove_add_in=dbcache' );
 					throw new Util_WpFile_FilesystemOperationException(
 						sprintf( __( 'The Database add-in file db.php is not a W3 Total Cache drop-in.

--- a/ObjectCache_Environment.php
+++ b/ObjectCache_Environment.php
@@ -115,7 +115,7 @@ class ObjectCache_Environment {
 					if ( isset( $_GET['page'] ) )
 						$url = 'admin.php?page=' . $_GET['page'] . '&amp;';
 					else
-						$url = basename( Util_Environment::remove_query(
+						$url = basename( Util_Environment::remove_query_all(
 								$_SERVER['REQUEST_URI'] ) ) . '?page=w3tc_dashboard&amp;';
 					$remove_url = Util_Ui::admin_url( $url .
 						'w3tc_default_remove_add_in=objectcache' );

--- a/lib/Minify/Minify/CSS/UriRewriter.php
+++ b/lib/Minify/Minify/CSS/UriRewriter.php
@@ -434,11 +434,10 @@ class Minify_CSS_UriRewriter {
 
                 if (preg_match('~\.([a-z-_]+)(\?.*)?$~', $uri, $matches)) {
                     $extension = $matches[1];
-                    $query = (isset($matches[2]) ? $matches[2] : '');
 
                     if ($extension && in_array($extension, self::$_browserCacheExtensions)) {
                         $uri = \W3TC\Util_Environment::remove_query($uri);
-                        $uri .= ($query ? '&' : '?') . self::$_browserCacheId;
+                        $uri .= ( strpos( $uri, '?' ) !== false ? '&' : '?' ) . self::$_browserCacheId;
                     }
                 }
             }


### PR DESCRIPTION
The `remove_query()` function is used to strip out WP's query string name-value pair from a URL.  More specifically, it removes the _ver=4.#.#_ held within a query string.  However, some problems were identified:

* In `DbCache_Environment.php` and `ObjectCache_Environment.php` the line show below has an issue.  This line generates a new URL with its own query string.  However, it uses `remove_query()` which can still potentially return back a query string of its own.  Recall that `remove_query()` _only_ strips out _ver=4.#.#_.   It seems the author's intention was to use `remove_query_all()`, which strips out a query string entirely, readying it for the new one: `'?page=w3tc_dashboard&amp;'`:

```php
$url = basename( Util_Environment::remove_query( $_SERVER['REQUEST_URI'] ) ) . '?page=w3tc_dashboard&amp;';
```

* When using the _Prevent Caching of Objects After Settings Change_ feature for CSS & JS files, inside `UriRewriter.php`, which handles URIs contained in CSS files,  there is a check to see if a query string exists.  If so, then it follows by stripping _?ver=4.#.#_ and then attaching `$_browserCacheId`.  The problem is that if the URI query string consisted only of _?ver=4.#.#_ the final URI will end up malformed (e.g., it would end up like this: _**test.css&x47202**_ instead of this: _**test.css?x47202**_).

:octocat: 