### PR TITLE
Enhance "remove_query()" to Recognize Other Ampersand Forms

### DIFF
--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -835,7 +835,7 @@ class Util_Environment {
 	 * Removes WP query string from URL
 	 */
 	static public function remove_query( $url ) {
-		$url = preg_replace( '~[&\?]+(ver=([a-z0-9-_\.]+|[0-9-]+))~i', '', $url );
+		$url = preg_replace( '~(\?|&amp;|&#038;|&)+ver=[a-z0-9-_\.]+~i', '', $url );
 
 		return $url;
 	}


### PR DESCRIPTION
The `remove_query()` function strips out the WP Query String name-value pair (e.g., _ver=4.#.#_), if it exists.  But because this name-value pair can start with either **?** or **&** the previous code did not take into account the other forms of ampersand that WP passes to this function. Namely, **&# 038;** and **\&amp;**.  These other forms were indeed being  passed to `remove_query()` but were not being recognized until now. :octocat: 