### PR TITLE
WP Query String Being Stripped Unexpectedly

### DIFF
--- a/BrowserCache_Plugin.php
+++ b/BrowserCache_Plugin.php
@@ -179,7 +179,6 @@ class BrowserCache_Plugin {
 	private function mutate_url( $url, $mutate_by_querystring ) {
 		$id = $this->get_filename_uniqualizator();
 
-		$url = Util_Environment::remove_query( $url );
 		$query_pos = strpos( $url, '?' );
 
 		if ( $mutate_by_querystring ) {


### PR DESCRIPTION
When _Browser Cache_ is enabled and the user makes use of the _Prevent Caching of Objects After Settings Change_ feature, W3TC postfixes a unique query string identifier to an object's URL request.  It was discovered that the WP query string name-value pair (i.e., **?ver=4.7.2**), which is typically added at the end of these URLs, was being stripped.  This only happens when _Prevent Caching of Objects After Settings Change_ is enabled.  In other words, when that feature is disabled the WP query string is never stripped, and only gets stripped when using the W3TC _Minify_ feature.  This seems to indicate it is a bug.

There are legitimate cases for not stripping the WP query string under this context as was [pointed out here](https://wordpress.org/support/topic/w3-total-cache-incorrectly-removes-ver-parameter-from-css-styles-and-scripts/) where the user would set the version query value of scripts and styles to their respective last modified dates to better control caching. 

### Example
Prior to this fix an external script/stylesheet URL would look like this when _Prevent Caching of Objects After Settings Change_ is enabled (note the missing "**_ver=_**" query string variable):
![broken](https://cloud.githubusercontent.com/assets/5191497/22953629/0a64054e-f2e0-11e6-847d-7b4f36cea79d.png)

With this fix those same lines now look like this:
![working](https://cloud.githubusercontent.com/assets/5191497/22953632/0cb73226-f2e0-11e6-9452-a598fe23b92b.png)
:octocat: 