### PR TITLE
Malformed WP Query String

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -1229,9 +1229,20 @@ function w3_translate_file($file) {
  * @return string
  */
 function w3_remove_query($url) {
-    $url = preg_replace('~[&\?]+(ver=([a-z0-9-_\.]+|[0-9-]+))~i', '', $url);
+    $url = preg_replace('~(\?|&amp;|&#038;|&)+ver=[a-z0-9-_\.]+~i', '', $url);
 
     return $url;
+}
+
+/**
+ * Removes all query strings from url
+ */
+function w3_remove_query_all($url) {
+    $pos = strpos( $url, '?' );
+    if ( $pos === false )
+        return $url;
+
+    return substr( $url, 0, $pos );
 }
 
 /**

--- a/lib/Minify/Minify/CSS/UriRewriter.php
+++ b/lib/Minify/Minify/CSS/UriRewriter.php
@@ -264,11 +264,10 @@ class Minify_CSS_UriRewriter {
 
                 if (preg_match('~\.([a-z-_]+)(\?.*)?$~', $uri, $matches)) {
                     $extension = $matches[1];
-                    $query = (isset($matches[2]) ? $matches[2] : '');
 
                     if ($extension && in_array($extension, self::$_browserCacheExtensions)) {
                         $uri = w3_remove_query($uri);
-                        $uri .= ($query ? '&' : '?') . self::$_browserCacheId;
+                        $uri .= ( strpos( $uri, '?' ) !== false ? '&' : '?' ) . self::$_browserCacheId;
                     }
                 }
             }

--- a/lib/W3/DbCacheAdminEnvironment.php
+++ b/lib/W3/DbCacheAdminEnvironment.php
@@ -107,7 +107,7 @@ class W3_DbCacheAdminEnvironment {
                 if (isset($_GET['page']))
                     $url = 'admin.php?page=' . $_GET['page'] . '&amp;';
                 else
-                    $url = basename(w3_remove_query($_SERVER['REQUEST_URI'])) . '?page=w3tc_dashboard&amp;';
+                    $url = basename(w3_remove_query_all($_SERVER['REQUEST_URI'])) . '?page=w3tc_dashboard&amp;';
                 $remove_url = w3_admin_url($url . 'w3tc_default_remove_add_in=dbcache');
                 throw new FilesystemOperationException(
                     sprintf(__('The Database add-in file db.php is not a W3 Total Cache drop-in.

--- a/lib/W3/ObjectCacheAdminEnvironment.php
+++ b/lib/W3/ObjectCacheAdminEnvironment.php
@@ -106,7 +106,7 @@ class W3_ObjectCacheAdminEnvironment {
                 if (isset($_GET['page']))
                     $url = 'admin.php?page=' . $_GET['page'] . '&amp;';
                 else
-                    $url = basename(w3_remove_query($_SERVER['REQUEST_URI'])) . '?page=w3tc_dashboard&amp;';
+                    $url = basename(w3_remove_query_all($_SERVER['REQUEST_URI'])) . '?page=w3tc_dashboard&amp;';
                 $remove_url = w3_admin_url($url . 'w3tc_default_remove_add_in=objectcache');
 
                 throw new FilesystemOperationException(

--- a/lib/W3/Plugin/BrowserCache.php
+++ b/lib/W3/Plugin/BrowserCache.php
@@ -146,7 +146,6 @@ class W3_Plugin_BrowserCache extends W3_Plugin {
         if ($id === null)
             $id = $this->get_replace_id();
 
-        $url = w3_remove_query($url);
         $url .= (strstr($url, '?') !== false ? '&amp;' : '?') . $id;
 
         if ($attr != 'w3tc_load_js(')
@@ -163,7 +162,7 @@ class W3_Plugin_BrowserCache extends W3_Plugin {
     function w3tc_cdn_url($url, $original_url) {
         // decouple extension
         $matches = array();
-        if (!preg_match('/\.([a-zA-Z0-9]+)$/', $original_url, $matches))
+        if (!preg_match('/\.([a-zA-Z0-9]+)($|[\?])/', $original_url, $matches))
             return $url;
         $extension = $matches[1];
 

--- a/lib/W3/Plugin/Cdn.php
+++ b/lib/W3/Plugin/Cdn.php
@@ -281,9 +281,9 @@ class W3_Plugin_Cdn extends W3_Plugin {
                 if ($this->_config->get_boolean('cdn.includes.enable')) {
                     $mask = $this->_config->get_string('cdn.includes.files');
                     if ($mask != '') {
-                        $regexps[] = '~(["\'(])\s*((' . $domain_url_regexp . ')?(' . w3_preg_quote($site_path . WPINC) . '/(' . $this->get_regexp_by_mask($mask) . ')))~';
+                        $regexps[] = '~(["\'(])\s*((' . $domain_url_regexp . ')?(' . w3_preg_quote($site_path . WPINC) . '/(' . $this->get_regexp_by_mask($mask) . ')([^"\'() >]*)))~';
                         if ($site_domain_url_regexp)
-                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($site_path . WPINC) . '/(' . $this->get_regexp_by_mask($mask) . ')))~';
+                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($site_path . WPINC) . '/(' . $this->get_regexp_by_mask($mask) . ')([^"\'() >]*)))~';
                     }
                 }
 
@@ -293,11 +293,11 @@ class W3_Plugin_Cdn extends W3_Plugin {
                     $mask = $this->_config->get_string('cdn.theme.files');
 
                     if ($mask != '') {
-                        $regexps[] = '~(["\'(])\s*((' . $domain_url_regexp . ')?(' . w3_preg_quote($theme_dir) . '/(' . $this->get_regexp_by_mask($mask) . ')))~';
+                        $regexps[] = '~(["\'(])\s*((' . $domain_url_regexp . ')?(' . w3_preg_quote($theme_dir) . '/(' . $this->get_regexp_by_mask($mask) . ')([^"\'() >]*)))~';
                         if ($site_domain_url_regexp) {
                             $theme_dir2 = preg_replace('~' . $site_domain_url_regexp. '~i', '', get_theme_root_uri());
-                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($theme_dir) . '/(' . $this->get_regexp_by_mask($mask) . ')))~';
-                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($theme_dir2) . '/(' . $this->get_regexp_by_mask($mask) . ')))~';
+                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($theme_dir) . '/(' . $this->get_regexp_by_mask($mask) . ')([^"\'() >]*)))~';
+                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($theme_dir2) . '/(' . $this->get_regexp_by_mask($mask) . ')([^"\'() >]*)))~';
                         }
                     }
                 }
@@ -317,9 +317,9 @@ class W3_Plugin_Cdn extends W3_Plugin {
                             }
                         }
 
-                        $regexps[] = '~(["\'(])\s*((' . $domain_url_regexp . ')?(' . w3_preg_quote($site_path) . '(' . implode('|', $mask_regexps) . ')))~i';
+                        $regexps[] = '~(["\'(])\s*((' . $domain_url_regexp . ')?(' . w3_preg_quote($site_path) . '(' . implode('|', $mask_regexps) . ')([^"\'() >]*)))~i';
                         if ($site_domain_url_regexp)
-                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($site_path) . '(' . implode('|', $mask_regexps) . ')))~i';
+                            $regexps[] = '~(["\'(])\s*((' . $site_domain_url_regexp . ')?(' . w3_preg_quote($site_path) . '(' . implode('|', $mask_regexps) . ')([^"\'() >]*)))~i';
                     }
                 }
 


### PR DESCRIPTION
Very similar bug to # 384 but for the v0.9.4.x generation.  There are differences though in that the bug in v0.9.5.x happened all the time when the _Prevent Caching of Objects After Settings Change_ feature was enabled.  This bug for v0.9.4.x only occurred when  _Prevent Caching of Objects After Settings Change_ was enabled and CDN was disabled.

However, when CDN was enabled a uniquely different bug occurred.  It would result in malformed URLs having two "?", one for the unique identifier set by W3TC, and another for the **_?ver_** WP query string identifier.
