### PR TITLE
Filter to Set Cache Lifetime Period On A Per-Page Basis 

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1879,6 +1879,16 @@ class PgCache_ContentGrabber {
 		} elseif ( $this->_sitemap_matched )
 			$group = 'sitemaps';
 
+        /**
+         * Filters the current theme page cache lifetime.
+         *
+         * @param integer $_lifetime      The page cache lifetime.
+         * @param string  $_request_uri   The URI of the page.
+         * @param integer $mobile_group   The request's mobile group.
+         * @param integer $referrer_group The request's referrer group.
+         */
+        $_expire = apply_filters('w3tc_pgcache_lifetime', $this->_lifetime, $this->_request_uri, $mobile_group, $referrer_group);
+
 		foreach ( $compressions_to_store as $_compression ) {
 			$this->_set_extract_page_key( $mobile_group,
 				$referrer_group, $encryption, $_compression,
@@ -1902,7 +1912,7 @@ class PgCache_ContentGrabber {
 			$_data = apply_filters( 'w3tc_pagecache_set', $_data, $this->_page_key );
 
 			if ( !empty( $_data ) )
-				$cache->set( $this->_page_key, $_data, $this->_lifetime, $group );
+				$cache->set( $this->_page_key, $_data, $_expire, $group );
 		}
 
 		// Change buffer if using compression


### PR DESCRIPTION
Adds a new filter called **`w3tc_pgcache_lifetime`** allowing the user to set how long (in seconds) a given URI should be cached.  This feature is available for all _Page Cache Methods_ except for _Disk: Enhanced_.

## How To Use This Filter
The following example sets the page cache lifetime to 60 seconds when the page being cached is: http://domain.com/sample-page/
```php
/*
 * @param integer $lifetime_secs     The page cache lifetime (in seconds).
 * @param string  $request_uri       The URI of the page.
 * @param integer $mobile_group      The request's mobile group.
 * @param integer $referrer_group    The request's referrer group.
 */
function my_cache_lifetime( $lifetime_secs, $request_uri, $mobile_group, $referrer_group )
{	
    if ( $request_uri == "/sample-page/" )
        $lifetime_secs = 60;

    return $lifetime_secs;
}
add_filter( 'w3tc_pgcache_lifetime', 'my_cache_lifetime', 10, 4 );
```
:octocat: 