### PR TITLE
Warning: _Invalid Arguments in Minify_Environment.php

### DIFF
--- a/Minify_Environment.php
+++ b/Minify_Environment.php
@@ -271,13 +271,21 @@ class Minify_Environment {
 				$response['response']['code'] == 200 &&
 				trim( $response['body'] ) == 'Minify OK' );
 
-			if ( $is_ok )
+			if ( $is_ok ){
 				$result = 'ok';
-			else
-				$result = is_wp_error( $response ) ?
-					$response->get_error_message() :
-					implode( ' ', $response['body'] );
-
+			} else {
+				if( is_wp_error( $response ) ){
+					$result = $response->get_error_message();
+				} elseif ( isset($response['body']) ) {
+					if( is_array($response['body']) ){
+					    $result = implode( ' ', $response['body'] );
+					} else {
+						$result = $response['body'];
+					}
+				} else {
+					$result = $response;
+				}
+			}
 			set_site_transient( $key, $result, 30 );
 		}
 


### PR DESCRIPTION
founded in my error log:

> Warning: implode(): Invalid arguments passed in /wp-content/plugins/w3-total-cache/Minify_Environment.php on line 279

this pr is a simple error handling improvements.

this error happen because my cheap hosting has made some magic for block curl request and the curl return value is unexpected by w3tc (note the italian message):

![immagine](https://cloud.githubusercontent.com/assets/310077/23042929/e4160704-f49a-11e6-865b-5d61fdce70ae.jpg)
