### PR TITLE
Feeds Not Caching Nor Serving Back as XML

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -345,6 +345,10 @@ $keys = array(
 		'type' => 'boolean',
 		'default' => false
 	),
+	'pgcache.cache.apache_handle_xml' => array(
+		'type' => 'boolean',
+		'default' => false
+	),
 	'pgcache.cache.ssl' => array(
 		'type' => 'boolean',
 		'default' => false

--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -138,7 +138,7 @@ class Minify_Plugin {
 	 * @return string
 	 */
 	function ob_callback( $buffer ) {
-		$enable = Util_Content::is_html( $buffer ) &&
+		$enable = Util_Content::is_html_xml( $buffer ) &&
 			$this->can_minify2( $buffer );
 		$enable = apply_filters( 'w3tc_minify_enable', $enable );
 		if ( !$enable )

--- a/PgCache_ConfigLabels.php
+++ b/PgCache_ConfigLabels.php
@@ -55,6 +55,7 @@ class PgCache_ConfigLabels {
 				'pgcache.accept.uri' =>  __( 'Non-trailing slash pages:', 'w3-total-cache' ),
 				'pgcache.cache.headers' =>  __( 'Specify page headers:', 'w3-total-cache' ),
 				'pgcache.cache.nginx_handle_xml' => __( 'Handle <acronym title="Extensible Markup Language">XML</acronym> mime type', 'w3-total-cache' ),
+				'pgcache.cache.apache_handle_xml' => __( 'Handle <acronym title="Extensible Markup Language">XML</acronym> mime type', 'w3-total-cache' ),
 			) );
 	}
 }

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1305,17 +1305,24 @@ class PgCache_ContentGrabber {
 			$key .= '_preview';
 		}
 
-		if ( $this->_enhanced_mode ) {
-			/**
-			 * Append HTML extension.
-			 * For nginx - we create .xml cache entries and redirect to them
-			 */
-			if ( Util_Environment::is_nginx() && substr( $content_type, 0, 8 ) == 'text/xml' &&
-				$this->_config->get_boolean( 'pgcache.cache.nginx_handle_xml' ) )
-				$key .= '.xml';
-			else
-				$key .= '.html';
-		}
+        if ( $this->_enhanced_mode ) {
+            $ext = "html";
+            if ( @preg_match( "~(text/xml|text/xsl|application/rdf\+xml|application/rss\+xml|application/atom\+xml)~i", $content_type ) ||
+                strpos( $this->_request_uri, "/feed/" ) !== false ||
+                strpos( $this->_request_uri, ".xsl" ) !== false ) {
+                $ext = "xml";
+            }
+            if ( Util_Environment::is_nginx() ) {
+                if ( !$this->_config->get_boolean( 'pgcache.cache.nginx_handle_xml' ) ) {
+                    $ext = "html";
+                }
+            } else {
+                if ( !$this->_config->get_boolean( 'pgcache.cache.apache_handle_xml' ) ) {
+                    $ext = "html";
+                }
+            }
+            $key .= ".$ext";
+        }
 
 		/**
 		 * Append compression
@@ -1736,8 +1743,8 @@ class PgCache_ContentGrabber {
 		$cache_headers = apply_filters( 'w3tc_is_cacheable_content_type',
 			array(
 				'' /* redirects, they have only Location header set */,
-				'application/json', 'text/html', 'text/xml',
-				'application/xhtml+xml'
+				'application/json', 'text/html', 'text/xml', 'text/xsl',
+				'application/xhtml+xml', 'application/rss+xml', 'application/atom+xml', 'application/rdf+xml'
 			)
 		);
 		return in_array( $content_type, $cache_headers );

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -764,6 +764,14 @@ class PgCache_Environment {
 		$rules .= "    RewriteRule .* \"" . $uri_prefix . $ext .
 			$env_W3TC_ENC . "\" [L]\n";
 
+        if ($config->get_boolean('pgcache.cache.apache_handle_xml')) {
+            $ext = '.xml';
+            $rules .= "    RewriteCond \"" . $document_root . $uri_prefix . $ext .
+                $env_W3TC_ENC . "\"" . $switch . "\n";
+            $rules .= "    RewriteRule .* \"" . $uri_prefix . $ext .
+                $env_W3TC_ENC . "\" [L]\n";
+        }
+
 		$rules .= "</IfModule>\n";
 
 		$rules .= W3TC_MARKER_END_PGCACHE_CORE . "\n";

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -436,12 +436,12 @@ echo sprintf(
 					<span class="description"><?php _e( 'Specify additional page headers to cache.', 'w3-total-cache' )?></span>
 				</td>
 			</tr>
-			<?php if ( Util_Environment::is_nginx() && $this->_config->get_string( 'pgcache.engine' ) == 'file_generic' ): ?>
+			<?php if ( $this->_config->get_string( 'pgcache.engine' ) == 'file_generic' ): ?>
 			<tr>
-				<th><label><?php Util_Ui::e_config_label( 'pgcache.cache.nginx_handle_xml' ) ?></label></th>
+				<th><label><?php Util_Ui::e_config_label(Util_Environment::is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml') ?></label></th>
 				<td>
-					<?php $this->checkbox( 'pgcache.cache.nginx_handle_xml', true ) ?> <?php Util_Ui::e_config_label( 'pgcache.cache.nginx_handle_xml' ) ?></label><br />
-					<span class="description"><?php _e( 'Return correct Content-Type header for XML files. Slows down cache engine.', 'w3-total-cache' ); ?></span>
+					<?php $this->checkbox(Util_Environment::is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml', Util_Environment::is_nginx()?true:false) ?> <?php Util_Ui::e_config_label(Util_Environment::is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml') ?></label><br />
+					<span class="description"><?php _e( 'Return correct Content-Type header for XML files (e.g., feeds and sitemaps). Slows down cache engine.', 'w3-total-cache' ); ?></span>
 				</td>
 			</tr>
 			<?php endif; ?>


### PR DESCRIPTION
When using the `Cache Feeds` checkbox under _Page Cache_ it is suppose to cache feeds as identified by WP's `is_feed()` function.  However, W3TC assumed the content type of feeds was just _text/xml_ (which was true in older WP versions) but current WP iterations (for some time now) set the feed content types to _application/rss+xml_, _application/atom+xml_, etc.  As such, prior to this fix W3TC did not cache any feeds (that i know of).

With this patch, when for example _Disk: Enhanced_ is used, you will see a directory called _feed_ created containing the  cached file of the feed.

Several tests show the problem is fixed and works really well.  I can cache feeds (e.g., rss, rss2, atom, rdf) and retrieve them from cache properly.  Because caching feeds finally are working I recommend people use the "_Purge Policy_" checkboxes to manage when these cached feeds get cleared (e.g., when its associating post is updated or a new comment is made).

There was also a bug that preventing feeds and sitemaps from minifying.  It's now fixed and they validate successfully when using W3C's Feed Validator tool.

Interestingly, it was discovered when using _Disk: Enhanced_ W3TC always stores feeds and xml sitemaps as _index.html_, regardless of content type.  Because w3tc does not have any way of identifying what that content type was after being stored as _index.html_ it always serves back all pages as content type: _text/html_.  In other words, it doesn't set the **Content-Type:** header for _Disk: Enhanced_ responses and so the server is left to be the final decider by looking at the file extension.  As such, xml sitemaps which are suppose to return back as Content-Type: _text/xml_ or rdf feeds as _application/rdf+xml_, will both return as _text/html_ to the client.  This will render client-side results visually incorrect (in some cases: garbled) even though the contents of that page will be proper.  So this is not a problem with the content it is a problem with the returning mime type being set (or more correctly, not being set) for _Disk: Enhanced_.

For NGINX users this problem is solved by using the "_Handle XML Mime Type_" checkbox, which appears at the bottom of _Page Cache_, allowing W3TC to set feeds and xml sitemap cached files using a _.xml_ file extension.  This patch extends this ability by offering the same checkbox for Apache users as well.  It even goes one step further for _Disk: Enhanced_ mode by updating the _.htaccess_ file to be aware of potentially cached xml types -- improving performance.

So, in summation this fix allows feeds and xml sitemaps to be cached and minified correctly and return back their proper mime content-type so they can render accurately. :octocat: 

**Edit**, see https://github.com/szepeviktor/w3-total-cache-fixed/issues/454




