### PR TITLE
A Few More Useful Smart Default Settings

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -532,7 +532,7 @@ $keys = array(
 	),
 	'pgcache.purge.sitemap_regex' => array(
 		'type' => 'string',
-		'default' => '([a-z0-9_\-]*?)sitemap([a-z0-9_\-]*)?\.xml'
+		'default' => '[a-z0-9_\-]*sitemap[a-z0-9_\-]*\.(xml|xsl|html?)(\.gz)?'
 	),
 	'pgcache.prime.enabled' => array(
 		'type' => 'boolean',
@@ -684,7 +684,8 @@ $keys = array(
 		'type' => 'array',
 		'default' => array(
 			'google_ad_',
-			'RSPEAK_'
+			'RSPEAK_',
+			'mfunc'
 		)
 	),
 	'minify.css.combine' => array(
@@ -1455,7 +1456,7 @@ $keys = array(
 		'type' => 'array',
 		'default' => array(
 			'robots\.txt',
-			'[a-z0-9_\-]*sitemap[a-z0-9_\-]*\.(xml|xsl|html)(\.gz)?'
+			'[a-z0-9_\-]*sitemap[a-z0-9_\-]*\.(xml|xsl|html?)(\.gz)?'
 		)
 	),
 	'browsercache.cssjs.last_modified' => array(


### PR DESCRIPTION
A few updates into the default configuration settings to include a more refined regular expression for sitemaps.  Since not all sitemaps have the same naming convention, this better assures to capture most of the common ones, including ones that rely on xsl companions.

It also adds fragment cache's unique `mfunc` identifier as a default entry into the _Ignored Comment Stems_ field.  Way too many times have people forgotten to include this identifier, causing unnecessary headaches.

:octocat: 