### PR TITLE
Expanded Regex Support & Improved Page Cache Cookies 

### DIFF
--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -527,18 +527,18 @@ class BrowserCache_Environment {
 		} else {
 			if ( $compatibility ) {
 				$rules .= "    FileETag None\n";
-				$headers_rules .= "         Header unset ETag\n";
+				$headers_rules .= "        Header unset ETag\n";
 			}
 		}
 
 		if ( $unset_setcookie )
-			$headers_rules .= "         Header unset Set-Cookie\n";
+			$headers_rules .= "        Header unset Set-Cookie\n";
 
 		if ( !$set_last_modified )
-			$headers_rules .= "         Header unset Last-Modified\n";
+			$headers_rules .= "        Header unset Last-Modified\n";
 
 		if ( $w3tc )
-			$headers_rules .= "         Header set X-Powered-By \"" .
+			$headers_rules .= "        Header set X-Powered-By \"" .
 				Util_Environment::w3tc_header() . "\"\n";
 
 		if ( strlen( $headers_rules ) > 0 ) {

--- a/Minify_Page.php
+++ b/Minify_Page.php
@@ -635,7 +635,20 @@ class Minify_Page extends Base_Page_Settings {
 		$files = array_map( array( '\W3TC\Util_Environment', 'normalize_file_minify' ), $files );
 		$files = array_unique( $files );
 		$ignore_files = $this->_config->get_array( 'minify.reject.files.js' );
-		$files = array_diff( $files, $ignore_files );
+
+        $ignore_files = str_replace( "~", "\~", $ignore_files ) );
+        Util_Rule::array_trim( $ignore_files );
+
+        if ( !empty( $ignore_files ) ) {
+            $diff = array();
+            foreach( $files as $file ) {
+                if ( !@preg_match( '~' . implode( "|", $ignore_files ) . '~i', $file ) ) {
+                    $diff[] = $file;
+                }
+            }
+            $files = $diff;                   
+        }
+
 		return $files;
 	}
 
@@ -654,7 +667,19 @@ class Minify_Page extends Base_Page_Settings {
 		$files = array_map( array( '\W3TC\Util_Environment', 'normalize_file_minify' ), $files );
 		$files = array_unique( $files );
 		$ignore_files = $this->_config->get_array( 'minify.reject.files.css' );
-		$files = array_diff( $files, $ignore_files );
+		
+        $ignore_files = str_replace( "~", "\~", $ignore_files ) );
+        Util_Rule::array_trim( $ignore_files );
+
+        if ( !empty( $ignore_files ) ) {
+            $diff = array();
+            foreach( $files as $file ) {
+                if ( !@preg_match( '~' . implode( "|", $ignore_files ) . '~i', $file ) ) {
+                    $diff[] = $file;
+                }
+            }
+            $files = $diff;                   
+        }
 
 		return $files;
 	}

--- a/Minify_Page.php
+++ b/Minify_Page.php
@@ -636,7 +636,7 @@ class Minify_Page extends Base_Page_Settings {
 		$files = array_unique( $files );
 		$ignore_files = $this->_config->get_array( 'minify.reject.files.js' );
 
-        $ignore_files = str_replace( "~", "\~", $ignore_files ) );
+        $ignore_files = str_replace( "~", "\~", $ignore_files );
         Util_Rule::array_trim( $ignore_files );
 
         if ( !empty( $ignore_files ) ) {
@@ -668,7 +668,7 @@ class Minify_Page extends Base_Page_Settings {
 		$files = array_unique( $files );
 		$ignore_files = $this->_config->get_array( 'minify.reject.files.css' );
 		
-        $ignore_files = str_replace( "~", "\~", $ignore_files ) );
+        $ignore_files = str_replace( "~", "\~", $ignore_files );
         Util_Rule::array_trim( $ignore_files );
 
         if ( !empty( $ignore_files ) ) {

--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -196,7 +196,6 @@ class Minify_Plugin {
 						$embed_pos = 0;
 				}
 
-				$ignore_css_files = array_map( array( '\W3TC\Util_Environment', 'normalize_file' ), $ignore_css_files );
 				$handled_styles = array();
 				$style_tags = Minify_Extract::extract_css( $buffer );
 				$previous_file_was_ignored = false;
@@ -228,7 +227,11 @@ class Minify_Plugin {
 
 					$handled_styles[] = $file;
 					$this->replaced_styles[] = $file;
-					if ( in_array( $file, $ignore_css_files ) ) {
+
+                    $ignore_css_files = str_replace( "~", "\~", $ignore_css_files ) );
+                    Util_Rule::array_trim( $ignore_css_files );
+
+					if ( !empty( $ignore_css_files ) && @preg_match( '~' . implode("|", $ignore_css_files ) . '~i', $file ) ) {
 						if ( $tag_pos > $embed_pos ) {
 							if ( $files_to_minify ) {
 								$data = array(
@@ -1040,17 +1043,18 @@ class Minify_Plugin {
 	 * @return boolean
 	 */
 	function check_ua() {
-		$uas = array_merge( $this->_config->get_array( 'minify.reject.ua' ), array(
-				W3TC_POWERED_BY
-			) );
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+            $uas = array_merge( $this->_config->get_array( 'minify.reject.ua' ), array(
+                    W3TC_POWERED_BY
+                ) );
 
-		foreach ( $uas as $ua ) {
-			if ( !empty( $ua ) ) {
-				if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && stristr( $_SERVER['HTTP_USER_AGENT'], $ua ) !== false ) {
-					return false;
-				}
-			}
-		}
+            $uas = str_replace( "~", "\~", $uas ) );
+            Util_Rule::array_trim( $uas );
+
+            if ( !empty( $uas ) && @preg_match( '~' . implode( "|", $uas ) . '~i', $_SERVER['HTTP_USER_AGENT'] ) ) {
+                return false;
+            }
+        }
 
 		return true;
 	}
@@ -1404,7 +1408,9 @@ class _W3_MinifyJsAuto {
 
 		// ignored files
 		$this->ignore_js_files = $this->config->get_array( 'minify.reject.files.js' );
-		$this->ignore_js_files = array_map( array( '\W3TC\Util_Environment', 'normalize_file' ), $this->ignore_js_files );
+
+        $this->ignore_js_files  = str_replace( "~", "\~", $this->ignore_js_files  ) );
+        Util_Rule::array_trim( $this->ignore_js_files  );
 
 		// define embed type
 		$this->embed_type = array(
@@ -1522,7 +1528,7 @@ class _W3_MinifyJsAuto {
 
 		$step1_result = $this->minify_helpers->is_file_for_minification( $script_src, $file );
 		$step1 = !empty( $step1_result );
-		$step2 = !in_array( $file, $this->ignore_js_files );
+		$step2 = empty( $this->ignore_js_files ) || !@preg_match( '~' . implode( "|", $this->ignore_js_files ) . '~i', $file );
 
 		$do_tag_minification = $step1 && $step2;
 		$do_tag_minification = apply_filters( 'w3tc_minify_js_do_tag_minification',

--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -228,7 +228,7 @@ class Minify_Plugin {
 					$handled_styles[] = $file;
 					$this->replaced_styles[] = $file;
 
-                    $ignore_css_files = str_replace( "~", "\~", $ignore_css_files ) );
+                    $ignore_css_files = str_replace( "~", "\~", $ignore_css_files );
                     Util_Rule::array_trim( $ignore_css_files );
 
 					if ( !empty( $ignore_css_files ) && @preg_match( '~' . implode("|", $ignore_css_files ) . '~i', $file ) ) {
@@ -1048,7 +1048,7 @@ class Minify_Plugin {
                     W3TC_POWERED_BY
                 ) );
 
-            $uas = str_replace( "~", "\~", $uas ) );
+            $uas = str_replace( "~", "\~", $uas );
             Util_Rule::array_trim( $uas );
 
             if ( !empty( $uas ) && @preg_match( '~' . implode( "|", $uas ) . '~i', $_SERVER['HTTP_USER_AGENT'] ) ) {
@@ -1409,7 +1409,7 @@ class _W3_MinifyJsAuto {
 		// ignored files
 		$this->ignore_js_files = $this->config->get_array( 'minify.reject.files.js' );
 
-        $this->ignore_js_files  = str_replace( "~", "\~", $this->ignore_js_files  ) );
+        $this->ignore_js_files  = str_replace( "~", "\~", $this->ignore_js_files  );
         Util_Rule::array_trim( $this->ignore_js_files  );
 
 		// define embed type

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -783,8 +783,8 @@ class PgCache_ContentGrabber {
         $accept_uri = $this->_config->get_array( 'pgcache.accept.files' );
         $accept_uri = array_map( array( '\W3TC\Util_Environment', 'parse_path' ), $accept_uri );
 
-        foreach ( $accept_uri as &$val ) $val = trim( str_replace( "~", "\~", $val ) );
-        $accept_uri = array_filter( $accept_uri, function( $val ){ return $val != ""; } );
+        $accept_uri = str_replace( "~", "\~", $accept_uri ) );
+        Util_Rule::array_trim( $accept_uri );
         if ( !empty( $accept_uri ) && @preg_match( '~' . implode( "|", $accept_uri ) . '~i', $this->_request_uri ) ) {
         	return true;
         }
@@ -864,7 +864,7 @@ class PgCache_ContentGrabber {
     function _check_custom_fields() {
         $reject_custom = $this->_config->get_array( 'pgcache.reject.custom' );
         foreach ( $reject_custom as &$val ) {
-            $val = preg_quote( trim( $val ), '~' );
+            $val = Util_Environment::preg_quote( trim( $val ) );
         }
 
         $reject_custom = implode( "|",array_filter( $reject_custom ) );
@@ -948,17 +948,21 @@ class PgCache_ContentGrabber {
 			}
 		}
 
-		foreach ( $this->_config->get_array( 'pgcache.reject.cookie' ) as $reject_cookie ) {
-			if ( !empty( $reject_cookie ) ) {
-				foreach ( array_keys( $_COOKIE ) as $cookie_name ) {
-					if ( strstr( $cookie_name, $reject_cookie ) !== false ) {
-						return false;
-					}
-				}
-			}
-		}
+        $reject_cookies = $this->_config->get_array( 'pgcache.reject.cookie' );
+        Util_Rule::array_trim( $reject_cookies );
 
-		return true;
+        $reject_cookies = str_replace( "+", " ", $reject_cookies );
+        $reject_cookies = array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $reject_cookies );
+
+        $reject_cookies = implode( '|', $reject_cookies );
+
+        foreach ( $_COOKIE as $key => $value ) {
+            if ( @preg_match( '~' . $reject_cookies . '~i', $key . "=$value" ) ) {
+                return false;
+            }
+        }
+
+        return true;
 	}
 
 	/**
@@ -1757,10 +1761,10 @@ class PgCache_ContentGrabber {
 	 */
     private function _check_query_string() {
         $accept_qs = $this->_config->get_array( 'pgcache.accept.qs' );
-        $accept_qs = array_filter( $accept_qs, function( $val ) { return $val != ""; } );
+        Util_Rule::array_trim( $accept_qs );
 
         foreach ( $accept_qs as &$val ) {
-            $val = preg_quote( trim( str_replace( "+", " ", $val ) ), "~" );
+            $val = Util_Environment::preg_quote( str_replace( "+", " ", $val ) );
             $val .=  ( strpos( $val, '=' ) === false ? '.*?' : '' );
         }
 

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -783,8 +783,9 @@ class PgCache_ContentGrabber {
         $accept_uri = $this->_config->get_array( 'pgcache.accept.files' );
         $accept_uri = array_map( array( '\W3TC\Util_Environment', 'parse_path' ), $accept_uri );
 
-        $accept_uri = str_replace( "~", "\~", $accept_uri ) );
+        $accept_uri = str_replace( "~", "\~", $accept_uri );
         Util_Rule::array_trim( $accept_uri );
+
         if ( !empty( $accept_uri ) && @preg_match( '~' . implode( "|", $accept_uri ) . '~i', $this->_request_uri ) ) {
         	return true;
         }
@@ -863,9 +864,9 @@ class PgCache_ContentGrabber {
      */
     function _check_custom_fields() {
         $reject_custom = $this->_config->get_array( 'pgcache.reject.custom' );
-        foreach ( $reject_custom as &$val ) {
-            $val = Util_Environment::preg_quote( trim( $val ) );
-        }
+		
+        Util_Rule::array_trim( $reject_custom );
+        $reject_custom = array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $reject_custom );
 
         $reject_custom = implode( "|",array_filter( $reject_custom ) );
 

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -595,12 +595,12 @@ class PgCache_Environment {
        /**
         * Set accept query strings
         */
-       $w3tc_query_strings = array_filter( $config->get_array( 'pgcache.accept.qs' ), function( $val ) { return $val != ""; } );
+       $w3tc_query_strings = $config->get_array( 'pgcache.accept.qs' );
+       Util_Rule::array_trim( $w3tc_query_strings );
 
        if ( !empty( $w3tc_query_strings ) ) {
-           foreach ( $w3tc_query_strings as &$val ) {
-               $val = trim( str_replace( " ", "\+", preg_quote( $val ) ) );
-           }
+           $w3tc_query_strings = str_replace( ' ', '+', $w3tc_query_strings );
+           $w3tc_query_strings = array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $w3tc_query_strings );
 
            $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%{QUERY_STRING}]\n";
 
@@ -735,8 +735,11 @@ class PgCache_Environment {
 		/**
 		 * Check for rejected cookies
 		 */
-		$use_cache_rules .= "    RewriteCond %{HTTP_COOKIE} !(" . implode( '|',
-			array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $reject_cookies ) ) . ") [NC]\n";
+        if ( !empty( $reject_cookies ) ) {
+            $reject_cookies = str_replace( ' ', '+', $reject_cookies );
+            $use_cache_rules .= "    RewriteCond %{HTTP_COOKIE} !(" . implode( '|',
+                array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $reject_cookies ) ) . ") [NC]\n";
+        }
 
 		/**
 		 * Check for rejected user agents
@@ -764,7 +767,7 @@ class PgCache_Environment {
 		$rules .= "    RewriteRule .* \"" . $uri_prefix . $ext .
 			$env_W3TC_ENC . "\" [L]\n";
 
-        if ($config->get_boolean('pgcache.cache.apache_handle_xml')) {
+        if ($config->get_boolean( 'pgcache.cache.apache_handle_xml' ) ) {
             $ext = '.xml';
             $rules .= "    RewriteCond \"" . $document_root . $uri_prefix . $ext .
                 $env_W3TC_ENC . "\"" . $switch . "\n";
@@ -852,12 +855,12 @@ class PgCache_Environment {
         /**
          * Set accept query strings
          */
-        $w3tc_query_strings = array_filter( $config->get_array( 'pgcache.accept.qs' ), function( $val ) { return $val != ""; } );
+        $w3tc_query_strings = $config->get_array( 'pgcache.accept.qs' );
+        Util_Rule::array_trim( $w3tc_query_strings );
 
         if ( !empty( $w3tc_query_strings ) ) {
-            foreach ( $w3tc_query_strings as &$val ) {
-                $val = trim( str_replace( " ", "\+", preg_quote( $val ) ) );
-            }
+           $w3tc_query_strings = str_replace( ' ', '+', $w3tc_query_strings );
+           $w3tc_query_strings = array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $w3tc_query_strings );
 
             $rules .= "set \$w3tc_query_string \$query_string;\n";
 
@@ -947,11 +950,13 @@ class PgCache_Environment {
 		/**
 		 * Check for rejected cookies
 		 */
-		$rules .= "if (\$http_cookie ~* \"(" . implode( '|',
-			array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $reject_cookies ) ) . ")\") {\n";
-		$rules .= "    set \$w3tc_rewrite 0;\n";
-		$rules .= "}\n";
-
+        if ( !empty( $reject_cookies ) ) {
+            $reject_cookies = str_replace( ' ', '+', $reject_cookies );
+            $rules .= "if (\$http_cookie ~* \"(" . implode( '|',
+                array_map( array( '\W3TC\Util_Environment', 'preg_quote' ), $reject_cookies ) ) . ")\") {\n";
+            $rules .= "    set \$w3tc_rewrite 0;\n";
+            $rules .= "}\n";
+        }
 		/**
 		 * Check for rejected user agents
 		 */

--- a/Util_Rule.php
+++ b/Util_Rule.php
@@ -22,10 +22,8 @@ class Util_Rule {
 	 * Removes empty elements
 	 */
 	static public function array_trim( &$a ) {
-		for ( $n = count( $a ) - 1; $n >= 0; $n-- ) {
-			if ( empty( $a[$n] ) )
-				array_splice( $a, $n, 1 );
-		}
+        $a = array_map( 'trim', $a );
+        $a = array_filter( $a, function( $val ) { return $val != ""; } );
 	}
 
 	/**

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -486,7 +486,7 @@ if ( $this->_config->get_string( 'minify.engine' ) == 'memcached' ) {
                 <td>
                     <textarea id="minify_reject_uri" name="minify__reject__uri"
                         <?php Util_Ui::sealing_disabled( 'minify.' ) ?> cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'minify.reject.uri' ) ) ); ?></textarea><br />
-                    <span class="description"><?php _e( 'Always ignore the specified pages / directories. Use relative paths. Omit: protocol, hostname, leading forward slash and query strings.', 'w3-total-cache' ); ?></span>
+                    <span class="description"><?php _e( 'Always ignore the specified pages / directories. Use relative paths. Supports regular expressions. Omit: protocol, hostname, leading forward slash and query strings.', 'w3-total-cache' ); ?></span>
                 </td>
             </tr>
             <tr>
@@ -494,7 +494,7 @@ if ( $this->_config->get_string( 'minify.engine' ) == 'memcached' ) {
                 <td>
                     <textarea id="minify_reject_files_js" name="minify__reject__files__js"
                         <?php Util_Ui::sealing_disabled( 'minify.' ) ?> cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'minify.reject.files.js' ) ) ); ?></textarea><br />
-                    <span class="description"><?php _e( 'Always ignore the specified <acronym title="JavaScript">JS</acronym> files. Use relative paths. Omit: protocol, hostname, leading forward slash and query strings.', 'w3-total-cache' ); ?></span>
+                    <span class="description"><?php _e( 'Always ignore the specified <acronym title="JavaScript">JS</acronym> files. Use relative paths. Supports regular expressions. Omit: protocol, hostname, leading forward slash and query strings.', 'w3-total-cache' ); ?></span>
                 </td>
             </tr>
             <tr>
@@ -502,7 +502,7 @@ if ( $this->_config->get_string( 'minify.engine' ) == 'memcached' ) {
                 <td>
                     <textarea id="minify_reject_files_css" name="minify__reject__files__css"
                         <?php Util_Ui::sealing_disabled( 'minify.' ) ?> cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'minify.reject.files.css' ) ) ); ?></textarea><br />
-                    <span class="description"><?php _e( 'Always ignore the specified <acronym title="Cascading Style Sheet">CSS</acronym> files. Use relative paths. Omit: protocol, hostname, leading forward slash and query strings.', 'w3-total-cache' ); ?></span>
+                    <span class="description"><?php _e( 'Always ignore the specified <acronym title="Cascading Style Sheet">CSS</acronym> files. Use relative paths. Supports regular expressions. Omit: protocol, hostname, leading forward slash and query strings.', 'w3-total-cache' ); ?></span>
                 </td>
             </tr>
             <tr>
@@ -511,7 +511,7 @@ if ( $this->_config->get_string( 'minify.engine' ) == 'memcached' ) {
                     <textarea id="minify_reject_ua" name="minify__reject__ua"
                         <?php Util_Ui::sealing_disabled( 'minify.' ) ?>
                         cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'minify.reject.ua' ) ) ); ?></textarea><br />
-                    <span class="description"><?php _e( 'Specify user agents that will never receive minified content.', 'w3-total-cache' ); ?></span>
+                    <span class="description"><?php _e( 'Specify user agents that will never receive minified content. Supports regular expressions.', 'w3-total-cache' ); ?></span>
                 </td>
             </tr>
             <?php if ( $auto ): ?>

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -354,7 +354,7 @@ if ( $this->_config->get_string( 'pgcache.engine' ) == 'memcached' ) {
 					<textarea id="pgcache_reject_cookie" name="pgcache__reject__cookie"
 						<?php Util_Ui::sealing_disabled( 'pgcache.' ) ?>
 						cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'pgcache.reject.cookie' ) ) ); ?></textarea><br />
-					<span class="description"><?php _e( 'Never cache pages that use the specified cookies.', 'w3-total-cache' ); ?></span>
+					<span class="description"><?php _e( 'Never cache pages that use these specified cookie name-value pairs. The value part is not required. But if used, separate name-value pairs with an equals sign (i.e., name=value). Each pair should be on their own line.', 'w3-total-cache' ); ?></span>
 				</td>
 			</tr>
 			<tr>
@@ -366,7 +366,7 @@ if ( $this->_config->get_string( 'pgcache.engine' ) == 'memcached' ) {
 					<span class="description">
 						<?php
 echo sprintf(
-	__( 'Always ignore the specified pages / directories. Supports regular expressions (See <a href="%s">FAQ</a>)', 'w3-total-cache' ),           network_admin_url( 'admin.php?page=w3tc_faq#q82' )
+	__( 'Always ignore the specified pages / directories. Use relative paths. Supports regular expressions (See <a href="%s">FAQ</a>)', 'w3-total-cache' ),           network_admin_url( 'admin.php?page=w3tc_faq#q82' )
 ); ?>
 					</span>
 				</td>
@@ -413,7 +413,7 @@ echo sprintf(
 					<textarea id="pgcache_accept_files" name="pgcache__accept__files"
 						<?php Util_Ui::sealing_disabled( 'pgcache.' ) ?>
 						cols="40" rows="5"><?php echo esc_textarea( implode( "\r\n", $this->_config->get_array( 'pgcache.accept.files' ) ) ); ?></textarea><br />
-					<span class="description"><?php echo sprintf( __( 'Cache the specified pages / directories even if listed in the "Never Cache" fields. Supports regular expression (See <a href="%s">FAQ</a>)', 'w3-total-cache' ), network_admin_url( 'admin.php?page=w3tc_faq#q82' ) ); ?></span>
+					<span class="description"><?php echo sprintf( __( 'Cache the specified pages / directories even if listed in the "Never Cache" fields. Use relative paths. Supports regular expression (See <a href="%s">FAQ</a>)', 'w3-total-cache' ), network_admin_url( 'admin.php?page=w3tc_faq#q82' ) ); ?></span>
 				</td>
 			</tr>
 			<?php if ( substr( $permalink_structure, -1 ) == '/' ): ?>

--- a/pub/css/widget.css
+++ b/pub/css/widget.css
@@ -145,3 +145,7 @@
 .maxcdn-netdna-widget-base.sign-up p span.desc {
     color:#8F8F8F;
 }
+
+#purge_urls {
+    width: 100%;
+}


### PR DESCRIPTION
To provide better robustness I added full regex support for the following Minify fields:

`Never Minify the Following JS Files`
`Never Minify the Following CSS Files`
`Rejected User Agents`

There have been several times in the past where having some regex support for the aforementioned fields would have resolved real-world user issues (e.g., dynamically generated js files with always changing names, which shouldn't be cached).

I also fixed an issue with Page Cache's `Reject Cookies` field.  It originally only accepted keys and so if someone gave a _key-value_ pair (as is common for cookies) it would have failed despite the key existing.  It now allows the user to provide (optionally) a value, in the form: `name=value`. Acceptable example entries could be: `mycookie=myvalue`, `plugin_login=`, `cookie_name`.

A minor tweak was also made to `Util_Rule::array_trim()` because although the function was suppose to trim a given array it was not; it was simply checking to see if the entries weren't empty.  It now trims and removes empty entries, effectively becoming a true array trimmer :smile: 

:octocat: 