### PR TITLE
"W3TC-Include-JS-Head" Tag Implementation Missing For Auto Mode

### DIFF
--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -1591,6 +1591,16 @@ class _W3_MinifyJsAuto {
 
 		// find embed position
 		$embed_pos = $this->embed_pos;
+		
+		if ( $this->minify_group_number <= 0 && $this->group_type == 'head' ) {
+			// try forced embed position
+			$forced_embed_pos = strpos($this->buffer, '<!-- W3TC-include-js-head -->');
+		
+			if ($forced_embed_pos !== false) {
+				$this->buffer = str_replace('<!-- W3TC-include-js-head -->', '', $this->buffer);
+				$embed_pos = $forced_embed_pos;
+			}
+		}
 
 		// build minified script tag
 		$data = array(


### PR DESCRIPTION
The v0.9.5.x branch's implementation of the **`<!-- W3TC-include-js-head -->`** special comment tag was found to be missing.  This PR re-implements this feature into the v0.9.5.x branch in the same way as the v0.9.4.x branch.

This issue was discovered under #391 investigation.