### PR TITLE
Add composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "szepeviktor/w3-total-cache-fixed",
+  "description": "W3 Total Cache (Fixed)",
+  "type": "wordpress-plugin",
+  "require": {}
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "szepeviktor/w3-total-cache-fixed",
+  "name": "szepeviktor/w3-total-cache",
   "description": "W3 Total Cache (Fixed)",
   "type": "wordpress-plugin",
   "require": {}


### PR DESCRIPTION
Fixed #403.

Usage example. In composer.json:

At the top:
```
    { 
      "type": "vcs",
      "url": "git@github.com:szepeviktor/w3-total-cache-fixed.git"
    },
```

Lower down:
```
  "require": {
...
    "szepeviktor/w3-total-cache-fixed": "v0.9.5.x-dev",
...
```

Finally, we use this config:
```
"extra": {
    "installer-paths": {
      "public/wp-content/plugins/{$name}/": [
        "type:wordpress-plugin"
      ]
    },
    "wordpress-install-dir": "public/wordpress"
  },
```