### PR TITLE
Debug Mode Not Working

### DIFF
--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -50,11 +50,10 @@ class Cdn_Plugin {
 				'cron_schedules'
 			) );
 
-		if ( !$this->_config->get_boolean( 'cdn.debug' ) )
-			add_filter( 'w3tc_footer_comment', array(
-					$this,
-					'w3tc_footer_comment'
-				) );
+		add_filter( 'w3tc_footer_comment', array(
+				$this,
+				'w3tc_footer_comment'
+			) );
 
 		if ( !Cdn_Util::is_engine_mirror( $cdn_engine ) ) {
 			add_action( 'delete_attachment', array(
@@ -725,16 +724,19 @@ class Cdn_Plugin {
 		$cdn = $common->get_cdn();
 		$via = $cdn->get_via();
 
-		$strings[] = sprintf(
+		$comment = sprintf(
 			__( 'Content Delivery Network via %s%s', 'w3-total-cache' ),
 			( $via ? $via : 'N/A' ),
 			( empty( $this->cdn_reject_reason ) ? '' :
 				sprintf( ' (%s)', $this->cdn_reject_reason ) ) );
 
 		if ( $this->_config->get_boolean( 'cdn.debug' ) ) {
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = "CDN debug info:";
-			$strings[] = sprintf( "%s%s", str_pad( 'Engine: ', 20 ),
-				$this->_config->get_string( 'cdn.engine' ) );
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
+			$strings[] = sprintf( "%s%s via %s", str_pad( 'Engine: ', 20 ),
+				$this->_config->get_string( 'cdn.engine' ),
+				( $via ? $via : 'N/A' ) );
 
 			if ( $this->cdn_reject_reason ) {
 				$strings[] = sprintf( "%s%s", str_pad( 'Reject reason: ', 20 ),
@@ -750,6 +752,9 @@ class Cdn_Plugin {
 						Util_Content::escape_comment( $new_url ) );
 				}
 			}
+		} elseif ( $this->_config->get_string( 'common.support' ) == '' &&
+					!$this->_config->get_boolean( 'common.tweeted' ) ){
+			$strings[] = $comment;
 		}
 
 		return $strings;

--- a/DbCache_WpdbInjection_QueryCaching.php
+++ b/DbCache_WpdbInjection_QueryCaching.php
@@ -613,7 +613,9 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 
 	public function w3tc_footer_comment( $strings ) {
 		if ( $this->debug ) {
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = "Db cache debug info:";
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = sprintf( "%s%s", str_pad( 'Engine: ', 20 ), Cache::engine_name( $this->_config->get_string( 'dbcache.engine' ) ) );
 			$strings[] = sprintf( "%s%d", str_pad( 'Total queries: ', 20 ), $this->query_total );
 			$strings[] = sprintf( "%s%d", str_pad( 'Cached queries: ', 20 ), $this->query_hits );
@@ -639,7 +641,8 @@ class DbCache_WpdbInjection_QueryCaching extends DbCache_WpdbInjection {
 						trim( $query['query'] ) );
 				}
 			}
-		} else {
+		} elseif ( $this->_config->get_string( 'common.support' ) == '' &&
+					!$this->_config->get_boolean( 'common.tweeted' ) ){
 			$reason = $this->get_reject_reason();
 			$append = ( $reason ? sprintf( ' (%s)', $reason ) : '' );
 

--- a/Extension_FragmentCache_WpObjectCache.php
+++ b/Extension_FragmentCache_WpObjectCache.php
@@ -572,7 +572,9 @@ class Extension_FragmentCache_WpObjectCache {
 	 */
 	public function w3tc_footer_comment( $strings ) {
 		if ( $this->_config->get_boolean( array( 'fragmentcache', 'debug' ) ) ) {
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = "Fragment Cache debug info:";
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = sprintf( "%s%s", str_pad( 'Engine: ', 20 ), Cache::engine_name( $this->_config->get_string( array( 'fragmentcache', 'engine' ) ) ) );
 			$strings[] = sprintf( "%s%s", str_pad( 'Caching: ', 20 ), ( $this->_caching ? 'enabled' : 'disabled' ) );
 

--- a/Generic_Plugin.php
+++ b/Generic_Plugin.php
@@ -490,28 +490,29 @@ class Generic_Plugin {
 				if ( Util_Environment::is_preview_mode() )
 					$buffer .= "\r\n<!-- W3 Total Cache used in preview mode -->";
 
-				if ( $this->_config->get_string( 'common.support' ) != '' ||
-					$this->_config->get_boolean( 'common.tweeted' ) ) {
-					$buffer .= sprintf( "\r\n<!-- Served from: %s @ %s by W3 Total Cache -->",
-						Util_Content::escape_comment( $host ), $date );
-				} else {
-					$strings = array();
-					$strings = apply_filters( 'w3tc_footer_comment', $strings );
+                $buffer .= "\r\n<!--\r\n";
 
-					$buffer .= "\r\n<!-- Performance optimized by W3 Total Cache. Learn more: https://www.w3-edge.com/products/\r\n";
+                $strings = array();
+                $strings = apply_filters( 'w3tc_footer_comment', $strings );
 
-					if ( count( $strings ) ) {
-						$buffer .= "\r\n" .
-							Util_Content::escape_comment( implode( "\r\n", $strings ) ) .
-							"\r\n";
-					}
+                if ( $this->_config->get_string( 'common.support' ) == '' &&
+                    !$this->_config->get_boolean( 'common.tweeted' ) ) {
+                    $buffer .= "Performance optimized by W3 Total Cache. Learn more: https://www.w3-edge.com/products/\r\n";
+                    if ( count( $strings ) ) {
+                        $buffer .= "\r\n";
+                    }
+                }
 
-					$buffer .= sprintf( "\r\n Served from: %s @ %s by W3 Total Cache -->", Util_Content::escape_comment( $host ), $date );
-				}
+                if ( count( $strings ) ) {
+                    $buffer .= Util_Content::escape_comment( implode( "\r\n", $strings ) ) . "\r\n\r\n";
+                }
+
+                $buffer .= sprintf( "Served from: %s @ %s by W3 Total Cache\r\n-->",
+                            Util_Content::escape_comment( $host ), $date );
 
 				$buffer = apply_filters( 'w3tc_process_content', $buffer );
-			}
-		
+			}			
+
 			$buffer = Util_Bus::do_ob_callbacks(
 				array( 'minify', 'newrelic', 'cdn', 'browsercache', 'pagecache' ),
 				$buffer );

--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -59,11 +59,10 @@ class Minify_Plugin {
 		add_filter( 'w3tc_admin_bar_menu',
 			array( $this, 'w3tc_admin_bar_menu' ) );
 
-		if ( !$this->_config->get_boolean( 'minify.debug' ) )
-			add_filter( 'w3tc_footer_comment', array(
-					$this,
-					'w3tc_footer_comment'
-				) );
+		add_filter( 'w3tc_footer_comment', array(
+				$this,
+				'w3tc_footer_comment'
+			) );
 
 		if ( $this->_config->get_string( 'minify.engine' ) == 'file' ) {
 			add_action( 'w3_minify_cleanup', array(
@@ -420,7 +419,7 @@ class Minify_Plugin {
 	}
 
 	function w3tc_footer_comment( $strings ) {
-		$strings[] = sprintf(
+		$comment = sprintf(
 			__( 'Minified using %s%s', 'w3-total-cache' ),
 			Cache::engine_name( $this->_config->get_string( 'minify.engine' ) ),
 			( $this->minify_reject_reason != ''
@@ -428,7 +427,9 @@ class Minify_Plugin {
 				: '' ) );
 
 		if ( $this->_config->get_boolean( 'minify.debug' ) ) {
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = "Minify debug info:";
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = sprintf( "%s%s", str_pad( 'Engine: ', 20 ), Cache::engine_name( $this->_config->get_string( 'minify.engine' ) ) );
 			$strings[] = sprintf( "%s%s", str_pad( 'Theme: ', 20 ), $this->get_theme() );
 			$strings[] = sprintf( "%s%s", str_pad( 'Template: ', 20 ), $this->get_template() );
@@ -456,6 +457,9 @@ class Minify_Plugin {
 					$strings[] = sprintf( "%d. %s\r\n", $index + 1, Util_Content::escape_comment( $file ) );
 				}
 			}
+		} elseif ( $this->_config->get_string( 'common.support' ) == '' &&
+					!$this->_config->get_boolean( 'common.tweeted' ) ){
+			$strings[] = $comment;
 		}
 
 		return $strings;

--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -412,8 +412,8 @@ class ObjectCache_WpObjectCache_Regular {
 
 		if ( $this->_debug ) {
 			$this->debug_info[] = array(
-				'id' => $id,
-				'group' => $group,
+				'id' => '',
+				'group' => '',
 				'operation' => 'flush',
 				'returned' => $reason,
 				'data_size' => 0,
@@ -841,7 +841,9 @@ class ObjectCache_WpObjectCache_Regular {
 
 	public function w3tc_footer_comment( $strings ) {
 		if ( $this->_config->get_boolean( 'objectcache.debug' ) ) {
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = "Object Cache debug info:";
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = sprintf( "%s%s", str_pad( 'Engine: ', 20 ), Cache::engine_name( $this->_config->get_string( 'objectcache.engine' ) ) );
 			$strings[] = sprintf( "%s%s", str_pad( 'Caching: ', 20 ), ( $this->_caching ? 'enabled' : 'disabled' ) );
 
@@ -874,7 +876,8 @@ class ObjectCache_WpObjectCache_Regular {
 					str_pad( $debug['group'], 15, ' ', STR_PAD_LEFT ),
 					$debug['id'] );
 			}
-		} else {
+		} elseif ( $this->_config->get_string( 'common.support' ) == '' &&
+					!$this->_config->get_boolean( 'common.tweeted' ) ){
 			$reason = $this->get_reject_reason();
 			$append = ( $reason != '' ? sprintf( ' (%s)', $reason ) : '' );
 

--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1349,18 +1349,19 @@ class PgCache_ContentGrabber {
 	 * @return string
 	 */
 	public function w3tc_footer_comment( $strings ) {
-		$strings[] = sprintf(
+		$comment = sprintf(
 			__( 'Page Caching using %s%s', 'w3-total-cache' ),
 			Cache::engine_name( $this->_config->get_string( 'pgcache.engine' ) ),
 			( $this->cache_reject_reason != ''
 				? sprintf( ' (%s)', $this->cache_reject_reason )
 				: '' ) );
 
-
 		if ( $this->_debug ) {
 			$time_total = Util_Debug::microtime() - $this->_time_start;
 			$engine = $this->_config->get_string( 'pgcache.engine' );
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = "Page cache debug info:";
+			$strings[] = "~~~~~~~~~~~~~~~~~~~~~~~~~~";
 			$strings[] = sprintf( "%s%s", str_pad( 'Engine: ', 20 ), Cache::engine_name( $engine ) );
 			$strings[] = sprintf( "%s%s", str_pad( 'Cache key: ', 20 ), $this->_page_key );
 
@@ -1379,9 +1380,12 @@ class PgCache_ContentGrabber {
 				foreach ( $headers['plain'] as $i ) {
 					$strings[] = sprintf( "%s%s",
 						str_pad( $i['name'] . ': ', 20 ),
-						Util_Content::escape_comment( $i['value'] ) );
+						Util_Content::escape_comment( trim( $i['value'] ) ) );
 				}
 			}
+		} elseif ( $this->_config->get_string( 'common.support' ) == '' &&
+					!$this->_config->get_boolean( 'common.tweeted' ) ){
+			$strings[] = $comment;
 		}
 
 		return $strings;


### PR DESCRIPTION
The _Debug Mode_ feature is a great way to help get more information when trying to figure out why a page isn't working.  However, there were a few issues:

1. When using _CDN_ or _Minify_, and enabling their respective debugging option, those specific debug information summary outputs did not display in the page footer.

2. If a user had opted to support W3TC (via the admin popup, a string can get assigned to `common.support` or a boolean of _true_ can be assigned to `common.tweeted`) and then decided to use the debug mode, no debug information would show in the footer for any caching feature.

   When supporting W3TC the intention is to only hide the:  _**Performance optimized by W3 Total Cache. Learn more: http:/\/www.w3-edge.com/products/**_ text display line that appears in page footers for users who have not opted into supporting W3TC, but by doing so it incorrectly also took away the debug information entirely (if debug mode was used) for those who did opt-in.

Both problems outlined above are now fixed in this patch. :octocat: 