### PR TITLE
PHP Deprecation Notice

### DIFF
--- a/Minify_Plugin.php
+++ b/Minify_Plugin.php
@@ -720,7 +720,6 @@ class Minify_Plugin {
 			case ( is_author() && ( $template_file = get_author_template() ) ):
 			case ( is_date() && ( $template_file = get_date_template() ) ):
 			case ( is_archive() && ( $template_file = get_archive_template() ) ):
-			case ( is_comments_popup() && ( $template_file = get_comments_popup_template() ) ):
 			case ( is_paged() && ( $template_file = get_paged_template() ) ):
 				break;
 


### PR DESCRIPTION
Was getting the PHP notice error: _**is_comments_popup is deprecated since version 4.5.0 with no alternative available**_. Bye, bye error! :octocat: 
