### PR TITLE
Catch Exceptions Thrown When Saving Config

### DIFF
--- a/Generic_Environment.php
+++ b/Generic_Environment.php
@@ -22,20 +22,24 @@ class Generic_Environment {
 		$this->add_index_to_folders();
 
 		if ( count( $exs->exceptions() ) <= 0 ) {
-			$f = file_exists( Config::util_config_filename( 0, false ) );
-			$f2 = file_exists( Config::util_config_filename_legacy_v2( 0, false ) );
-
-			$c = Dispatcher::config_master();
-			if ( ( $f || $f2 ) && $c->is_compiled() ) {
-				$c->save();
+			try {
 				$f = file_exists( Config::util_config_filename( 0, false ) );
+				$f2 = file_exists( Config::util_config_filename_legacy_v2( 0, false ) );
+
+				$c = Dispatcher::config_master();
+				if ( ( $f || $f2 ) && $c->is_compiled() ) {
+					$c->save();
+					$f = file_exists( Config::util_config_filename( 0, false ) );
+				}
+
+				if ( $f && $f2 )
+					@unlink( Config::util_config_filename_legacy_v2( 0, false ) );
+
+				if ( !$f && !$f2 && $config->get_integer( 'common.instance_id', 0 ) == 0 )
+					$this->notify_no_config_present( $config, $exs );
+			} catch ( \Exception $ex ) {
+				$exs->push( $ex );
 			}
-
-			if ( $f && $f2 )
-				@unlink( Config::util_config_filename_legacy_v2( 0, false ) );
-
-			if ( !$f && !$f2 && $config->get_integer( 'common.instance_id', 0 ) == 0 )
-				$this->notify_no_config_present( $config, $exs );
 		}
 
 		if ( count( $exs->exceptions() ) > 0 )


### PR DESCRIPTION
In our environment we do not allow the configuration file to be written since we are using a specially constructed file to load some parameters from environment variables. As of 0.9.5.2 this causes fatal errors on any W3TC settings page and on the plugins page in the admin interface. 

This is the error:

```
PHP Fatal error:  Uncaught exception 'Exception' with message 'Can't write to file <strong>/var/www/html/wp-content/w3tc-config/master.php</strong>' in /var/www/html/wp-content/plugins/w3-total-cache/Util_File.php:375
Stack trace:
#0 /var/www/html/wp-content/plugins/w3-total-cache/ConfigCompiler.php(241): W3TC\Util_File::file_put_contents_atomic('/var/www/html/w...', '<?php exit; ?>{...')
#1 /var/www/html/wp-content/plugins/w3-total-cache/Config.php(291): W3TC\ConfigCompiler->save()
#2 /var/www/html/wp-content/plugins/w3-total-cache/Generic_Environment.php(30): W3TC\Config->save()
#3 /var/www/html/wp-content/plugins/w3-total-cache/Root_Environment.php(28): W3TC\Generic_Environment->fix_on_wpadmin_request(Object(W3TC\Config), false)
#4 /var/www/html/wp-content/plugins/w3-total-cache/Generic_Plugin_Admin.php(705): W3TC\Root_Environment->fix_in_wpadmin(Object(W3TC\Config))
#5 [internal function]: W3TC\Generic_Plugin_Admin->admin_notices('')
#6 /var/www/html/wp-includes/class-wp-hook.php(...
```

`W3TC\Util_File->file_put_contents_atomic()` throws generic `\Exception` if the temporary or final files are not writeable. This is caught in `W3TC\Util_Admin->config_save()` for normal configuration save operations (e.g. the **Save All Settings** button in the admin interface), but not caught when called from `W3TC\Generic_Environment->fix_on_wpadmin_request()`

This change adds a try/catch block to catch this exception and  push it into `Util_Environment_Exceptions` for handling.

**Note**: The diff is messy since this involves an indentation change and one of the indented lines matches a line at the previous indentation level.


