### PR TITLE
Fix for the feeds on the dashboard

### DIFF
--- a/Root_Loader.php
+++ b/Root_Loader.php
@@ -47,7 +47,7 @@ class Root_Loader {
 			$plugins[] = new PgCache_Plugin_Admin();
 			$plugins[] = new Minify_Plugin_Admin();
 			$plugins[] = new Generic_WidgetSpreadTheWord_Plugin();
-			$plugins[] = new Generic_Plugin_WidgetNews();
+			//$plugins[] = new Generic_Plugin_WidgetNews();
 			$plugins[] = new Generic_Plugin_WidgetForum();
 			$plugins[] = new SystemOpCache_Plugin_Admin();
 

--- a/w3-total-cache-api.php
+++ b/w3-total-cache-api.php
@@ -11,7 +11,7 @@ define( 'W3TC_EMAIL', 'w3tc@w3-edge.com' );
 define( 'W3TC_TEXT_DOMAIN', 'w3-total-cache' );
 define( 'W3TC_LINK_URL', 'https://www.w3-edge.com/wordpress-plugins/' );
 define( 'W3TC_LINK_NAME', 'W3 EDGE, Optimization Products for WordPress' );
-define( 'W3TC_FEED_URL', 'http://feeds.feedburner.com/W3TOTALCACHE' );
+define( 'W3TC_FEED_URL', 'https://wordpress.org/support/plugin/w3-total-cache/feed' );
 define( 'W3TC_NEWS_FEED_URL', 'http://feeds.feedburner.com/W3EDGE' );
 define( 'W3TC_README_URL', 'http://plugins.svn.wordpress.org/w3-total-cache/trunk/readme.txt' );
 define( 'W3TC_SUPPORT_US_PRODUCT_URL', 'https://www.w3-edge.com/products/w3-total-cache/' );


### PR DESCRIPTION
This "partially" fix the issue https://github.com/szepeviktor/w3-total-cache-fixed/issues/396 (done 1/2)

Both widgets on the dashboard are broken because the feeds point to Feed Burner and Feed Burner seem don't update the feeds from 2015.

For the widget with the latest topic from the official w3tc forum i have replaced the Feed Burner url with the canonical url.

For the widget with the latest post from the official w3tc blog i can't found the canonical url, the blog seem without feed. In this case i have disabled the widget.

