### PR TITLE
Deprecated the "Allow, Deny, and Order" directives

### DIFF
--- a/Generic_Page_Dashboard_View.css
+++ b/Generic_Page_Dashboard_View.css
@@ -112,6 +112,34 @@
     float:left;
     margin-right:10px;
 }
+
+@media only screen and (max-device-width: 480px) {
+	#w3tc-dashboard-widgets #postbox-container-left {
+		margin-right: 0px;
+	}
+	#w3tc-dashboard-widgets {
+        min-width: auto;
+    }
+    #postbox-container-right {
+        width: 100%;
+        white-space: nowrap;
+        float: left;
+        margin-left: 0px;
+    }
+    #w3tc-dashboard-widgets {
+        background: none;
+    }
+    #w3tc-dashboard-widgets #normal-sortables .postbox {
+        width: 100%;
+    }
+    .w3tc_generic_widgetservice_label {
+        display: inline;
+    }
+    #cdn_maxcdn_authorization_key {
+        width: 100%;
+    }
+}
+
 /**
  * HiDPI Displays
  */

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -1188,10 +1188,27 @@ class PgCache_Environment {
 		if ( $compatibility ) {
 			$rules .= "Options -MultiViews\n";
 
-			// allow to read files by apache if they are blocked at some level above
-			$rules .= "<Files ~ \"\.(html|html_gzip|xml|xml_gzip)$\">\n";
-			$rules .= "  Allow from all\n";
-			$rules .= "</Files>\n";
+            // allow to read files by apache if they are blocked at some level above
+            $rules .= "<Files ~ \"\.(html|html_gzip|xml|xml_gzip)$\">\n";
+            $rules .= "  <IfModule mod_version.c>\n";
+            $rules .= "    <IfVersion < 2.4>\n";
+            $rules .= "      Order Allow,Deny\n";
+            $rules .= "      Allow from All\n";
+            $rules .= "    </IfVersion>\n";
+            $rules .= "    <IfVersion >= 2.4>\n";
+            $rules .= "      Require all granted\n";
+            $rules .= "    </IfVersion>\n";
+            $rules .= "  </IfModule>\n";
+            $rules .= "  <IfModule !mod_version.c>\n";
+            $rules .= "    <IfModule !mod_authz_core.c>\n";
+            $rules .= "      Order Allow,Deny\n";
+            $rules .= "      Allow from All\n";
+            $rules .= "    </IfModule>\n";
+            $rules .= "    <IfModule mod_authz_core.c>\n";
+            $rules .= "      Require all granted\n";
+            $rules .= "    </IfModule>\n";
+            $rules .= "  </IfModule>\n";
+            $rules .= "</Files>\n";
 
 			if ( !$etag ) {
 				$rules .= "FileETag None\n";


### PR DESCRIPTION
Apache v2.4+ has deprecated the "Allow, Deny, and Order" directives in .htaccess, in favor of the "Require" directive. Such servers would now be forced to load the "mod_access_compat" module to regain "Allow, Deny, and Order" (unlike pre-2.4). For w3tc's "Enable Compatibility Mode" to function correctly on servers that have upgraded i've put in the appropriate module condition check and corresponding directive.

Original fix for v0.9.4.x in the PR https://github.com/szepeviktor/w3-total-cache-fixed/pull/24