### PR TITLE
Specify a Cache Directory Outside Of The WP_CONTENT_DIR

### DIFF
--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -113,17 +113,10 @@ class Util_Environment {
      * @return string
      */
 	static public function filename_to_url( $filename, $use_site_url = false ) {
-		// using wp-content instead of document_root as known dir since dirbased
-		// multisite wp adds blogname to the path inside site_url
-		if ( substr( $filename, 0, strlen( WP_CONTENT_DIR ) ) != WP_CONTENT_DIR )
-			return '';
-		$uri_from_wp_content = substr( $filename, strlen( WP_CONTENT_DIR ) );
-
-		if ( DIRECTORY_SEPARATOR != '/' )
-			$uri_from_wp_content = str_replace( DIRECTORY_SEPARATOR, '/',
-				$uri_from_wp_content );
-
-		$url = content_url( $uri_from_wp_content );
+        // this code now allows you to go outside the WP_CONTENT_DIR for minifiied/cached files
+        $filenamePath = substr($filename, strlen(Util_Environment::document_root())-strlen($filename));
+        // this maps to to root home even on multisite.
+        $url = home_url($filenamePath);
 		$url = apply_filters( 'w3tc_filename_to_url', $url );
 
 		return $url;


### PR DESCRIPTION
**(SimoneNigro: merged with #423)**

WP_CONTENT_DIR.  Very useful for locking down WordPress except for this directory outside of WordPress.

In Summary:

1. What is the problem?
  You can't specify a directory for the cached files outside of WP_CONTENT_DIR it will return "" if you do.  It is beneficial to have this be able to so you can store minified and cached content outside the WordPress directory.  Useful to Lock down Wordpress directory.  Also, if you put Wordpress files in a subdirectory, i.e. /var/www/html/wp and have the index.html in /var/www/html and want to put the files in /var/www/html/resources the old code wouldn't let you.

2. Where is the cause?
  The current code checks if you are specifying a a file in WP_CONTENT_DIR.  If not, it returns "" empty string.
3. How was it solved?

By using document_root() trimming the filename, and mapping that to the network_home_url path.  This should work for multi-site as well, because the returned URL will NOT contain the single site blog i.e. /blog1/ path just like the original code
