### PR TITLE
Util_Environment::document_root() On Windows return / instead of \

### DIFF
--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -506,8 +506,6 @@ class Util_Environment {
 		return str_replace( '\\', DIRECTORY_SEPARATOR, $home_path );
 	}
 
-
-
 	/**
 	 * Returns absolute path to document root
 	 *
@@ -529,7 +527,7 @@ class Util_Environment {
 				$_SERVER['PHP_SELF'] );
 			if ( substr( $script_filename, -strlen( $php_self ) ) == $php_self ) {
 				$document_root = substr( $script_filename, 0, -strlen( $php_self ) );
-				$document_root = realpath( $document_root );
+				$document_root = Util_Environment::normalize_path(realpath( $document_root ));
 				return $document_root;
 			}
 		}
@@ -545,7 +543,7 @@ class Util_Environment {
 			$document_root = ABSPATH;
 		}
 
-		$document_root = realpath( $document_root );
+		$document_root = Util_Environment::normalize_path(realpath( $document_root ));
 		return $document_root;
 	}
 


### PR DESCRIPTION
from [docs](http://php.net/manual/en/function.realpath.php):

> On windows realpath() will change unix style paths to windows style.

`Util_Environment::document_root()` on windows return:

    C:\wordpress\

instead of:

    C:/wordpress/

and this cause some issue because w3tc working with unix style paths

An example of issue is in the `.htaccess`:

```
# BEGIN W3TC Page Cache core
<IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteBase /
    RewriteCond %{HTTP:Accept-Encoding} gzip
    RewriteRule .* - [E=W3TC_ENC:_gzip]
    RewriteCond %{HTTP_COOKIE} w3tc_preview [NC]
    RewriteRule .* - [E=W3TC_PREVIEW:_preview]
    RewriteCond %{REQUEST_METHOD} !=POST
    RewriteCond %{QUERY_STRING} =""
    RewriteCond %{REQUEST_URI} \/$
    RewriteCond %{HTTP_COOKIE} !(comment_author|wp\-postpass|w3tc_logged_out|wordpress_logged_in|wptouch_switch_toggle) [NC]
    RewriteCond %{HTTP_USER_AGENT} !(W3\ Total\ Cache) [NC]
    RewriteCond "%{DOCUMENT_ROOT}C:/DevEnv/htdocs/www.wordpress.local/w3tc-cache/page_enhanced/%{HTTP_HOST}/%{REQUEST_URI}/_index%{ENV:W3TC_PREVIEW}.html%{ENV:W3TC_ENC}" -f
    RewriteRule .* "C:/DevEnv/htdocs/www.wordpress.local/w3tc-cache/page_enhanced/%{HTTP_HOST}/%{REQUEST_URI}/_index%{ENV:W3TC_PREVIEW}.html%{ENV:W3TC_ENC}" [L]
</IfModule>
# END W3TC Page Cache core
```

see:

    RewriteCond "%{DOCUMENT_ROOT}C:/DevEnv/htdocs/www.wordpress.local/w3tc-cache/page_enhanced/%{HTTP_HOST}/%{REQUEST_URI}/_index%{ENV:W3TC_PREVIEW}.html%{ENV:W3TC_ENC}" -f

instead of

    RewriteCond "%{DOCUMENT_ROOT}/w3tc-cache/page_enhanced/%{HTTP_HOST}/%{REQUEST_URI}/_index%{ENV:W3TC_PREVIEW}.html%{ENV:W3TC_ENC}" -f