### PR TITLE
Customize Cache Directory

### DIFF
--- a/Util_Environment.php
+++ b/Util_Environment.php
@@ -107,27 +107,30 @@ class Util_Environment {
 		return $str;
 	}
 
-	/*
-     * Returns URL from filename/dirname
-     *
-     * @return string
-     */
-	static public function filename_to_url( $filename, $use_site_url = false ) {
-		// using wp-content instead of document_root as known dir since dirbased
-		// multisite wp adds blogname to the path inside site_url
-		if ( substr( $filename, 0, strlen( WP_CONTENT_DIR ) ) != WP_CONTENT_DIR )
-			return '';
-		$uri_from_wp_content = substr( $filename, strlen( WP_CONTENT_DIR ) );
+    /*
+    * Returns URL from filename/dirname
+    *
+    * @return string
+    */
+    static public function filename_to_url( $filename, $use_site_url = false ) {
+		
+        $document_root = Util_Environment::document_root();
+		
+        if ( substr( $filename, 0, strlen( $document_root ) ) != $document_root ){
+            return '';
+        }
+		
+        $uri_from_document_root = substr($filename, strlen($document_root) - strlen($filename));
+		
+        if ( DIRECTORY_SEPARATOR != '/' ){
+            $uri_from_document_root = str_replace( DIRECTORY_SEPARATOR, '/', $uri_from_document_root);
+        }
+		
+        $url = home_url($uri_from_document_root);
+        $url = apply_filters( 'w3tc_filename_to_url', $url );
 
-		if ( DIRECTORY_SEPARATOR != '/' )
-			$uri_from_wp_content = str_replace( DIRECTORY_SEPARATOR, '/',
-				$uri_from_wp_content );
-
-		$url = content_url( $uri_from_wp_content );
-		$url = apply_filters( 'w3tc_filename_to_url', $url );
-
-		return $url;
-	}
+        return $url;
+    }
 
 	/**
 	 * Returns true if database cluster is used


### PR DESCRIPTION
Original PR was made by @klhurley in https://github.com/szepeviktor/w3-total-cache-fixed/pull/421

In this pr i have replicate his improvements, with some twiks for Windows OS.

You can't specify a directory for the cached files outside of `WP_CONTENT_DIR`. It is beneficial to have this be able to so you can store minified and cached content outside the WordPress directory. Useful to Lock down Wordpress directory. 

The current code checks if you are specifying a a file in `WP_CONTENT_DIR`. If not, it returns `""` empty string.

By using `Util_Environment::document_root()` trimming the filename, and mapping that to the network `home_url` path. This should work for multi-site as well, because the returned URL will NOT contain the single site blog i.e.` /blog1/` path just like the original code.

For customize the cache directory, open `wp-config.php` and before
 `require_once(ABSPATH . 'wp-settings.php');` set `W3TC_CACHE_DIR`, eg.:

```php
/** Absolute path to the WordPress directory. */
if ( !defined('ABSPATH') )
	define('ABSPATH', dirname(__FILE__) . '/');

/** W3 Total Cache cache directory. */
define('W3TC_CACHE_DIR', ABSPATH.'w3tc-cache');

/** Sets up WordPress vars and included files. */
require_once(ABSPATH . 'wp-settings.php');
```

Thanks to @klhurley
