### PR TITLE
YUI Compressor: Fix for Empty JAVA executable path and JAVA path with spaces

### DIFF
--- a/lib/Minify/Minify/YUICompressor.php
+++ b/lib/Minify/Minify/YUICompressor.php
@@ -125,7 +125,14 @@ class Minify_YUICompressor {
             )
             ,$userOptions
         );
-        $cmd = self::$javaExecutable
+        
+        $javaExecutable = self::$javaExecutable;
+        
+        if( false !== strpos(trim($javaExecutable), ' ') ){
+        	$javaExecutable = '"'.$javaExecutable.'"';
+        }
+        
+        $cmd = $javaExecutable
 	         . (!empty($o['stack-size'])
 	            ? ' -Xss' . $o['stack-size']
 	            : '')

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -1153,24 +1153,24 @@ jQuery(function() {
             case 'yuijs':
                 jQuery.extend(params, {
                     engine: 'yuijs',
-                    path_java: jQuery('#minify__yuijs__path__java').val(),
-                    path_jar: jQuery('#minify__yuijs__path__jar').val()
+                    path_java: jQuery('#minify_yuijs_path_java').val(),
+                    path_jar: jQuery('#minify_yuijs_path_jar').val()
                 });
                 break;
 
             case 'yuicss':
                 jQuery.extend(params, {
                     engine: 'yuicss',
-                    path_java: jQuery('#minify__yuicss__path__java').val(),
-                    path_jar: jQuery('#minify__yuicss__path__jar').val()
+                    path_java: jQuery('#minify_yuicss_path_java').val(),
+                    path_jar: jQuery('#minify_yuicss_path_jar').val()
                 });
                 break;
 
             case 'ccjs':
                 jQuery.extend(params, {
                     engine: 'ccjs',
-                    path_java: jQuery('#minify__ccjs__path__java').val(),
-                    path_jar: jQuery('#minify__ccjs__path__jar').val()
+                    path_java: jQuery('#minify_ccjs_path_java').val(),
+                    path_jar: jQuery('#minify_ccjs_path_jar').val()
                 });
                 break;
             case 'googleccjs':


### PR DESCRIPTION
Two fix here.

1. W3TC on "Test YUI Compressor" always return "Empty JAVA executale path"

![2017-02-26_1559](https://cloud.githubusercontent.com/assets/310077/23377187/48487030-fd2f-11e6-9a07-664f2b9bc15d.png)

2. If java path has spaces (very common on windows) doesn't works

![immagine2](https://cloud.githubusercontent.com/assets/310077/23377304/d521d2bc-fd2f-11e6-98d0-c47c5244a9f5.jpg)


