### PR TITLE
Closure Compiler: fix JAVA path with spaces

### DIFF
--- a/lib/Minify/Minify/ClosureCompiler.php
+++ b/lib/Minify/Minify/ClosureCompiler.php
@@ -90,7 +90,14 @@ class Minify_ClosureCompiler {
             ),
             $userOptions
         );
-        $cmd = self::$javaExecutable . ' -jar ' . escapeshellarg(self::$jarFile)
+        
+        $javaExecutable = self::$javaExecutable;
+        
+        if( false !== strpos(trim($javaExecutable), ' ') ){
+        	$javaExecutable = '"'.$javaExecutable.'"';
+        }
+        	
+        $cmd = $javaExecutable . ' -jar ' . escapeshellarg(self::$jarFile)
              . (preg_match('/^[\\da-zA-Z0-9\\-]+$/', $o['charset'])
                 ? " --charset {$o['charset']}"
                 : '');


### PR DESCRIPTION
If java path has spaces (very common on windows) Closure Compiler doesn't works.

_Same as https://github.com/szepeviktor/w3-total-cache-fixed/pull/426_
