### PR TITLE
Extends "http 2 push" feature to page cache enhanced

### DIFF
--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -78,21 +78,53 @@ class Cache_File_Generic extends Cache_File {
 			@rename( $tmppath, $path );
 		}
 
-		@unlink( $tmppath );
+		@unlink( $tmppath ); 
 
 		$old_entry_path = $path . '.old';
 		@unlink( $old_entry_path );
 
-		if ( Util_Environment::is_apache() && isset( $var['headers'] ) &&
-			isset( $var['headers']['Content-Type'] ) &&
-			substr( $var['headers']['Content-Type'], 0, 8 ) == 'text/xml' ) {
-			file_put_contents( dirname( $path ) . '/.htaccess',
-				"<IfModule mod_mime.c>\n" .
-				"    RemoveType .html_gzip\n" .
-				"    AddType text/xml .html_gzip\n" .
-				"    RemoveType .html\n" .
-				"    AddType text/xml .html\n".
-				"</IfModule>" );
+		if ( Util_Environment::is_apache() && isset( $var['headers'] ) ) {
+			
+			$rules = '';
+			
+			if( isset( $var['headers']['Content-Type'] ) && substr( $var['headers']['Content-Type'], 0, 8 ) == 'text/xml' ){
+			
+				$rules .= "<IfModule mod_mime.c>\n";
+				$rules .= "    RemoveType .html_gzip\n";
+				$rules .= "    AddType text/xml .html_gzip\n";
+				$rules .= "    RemoveType .html\n";
+				$rules .= "    AddType text/xml .html\n";
+				$rules .= "</IfModule>\n";
+			}
+			
+			if( isset($var['headers'][0]) ){
+				
+				$links = '';
+				
+				for($i = 0; $i < 100; $i++){
+					
+					if( !isset($var['headers'][$i]) ){
+						break;
+					}
+					
+					$name  = isset($var['headers'][$i]['n']) ? $var['headers'][$i]['n'] : '';
+					$value = isset($var['headers'][$i]['v']) ? $var['headers'][$i]['v'] : '';
+					
+					if( ($name == 'Link') && (false !== strpos($value, 'rel=preload')) ){
+						$links .= "    Header add Link '".trim($var['headers'][$i]['v'])."'\n";
+					}
+				}
+				
+				if( !empty($links) ){
+					$rules .= "<IfModule mod_headers.c>\n";
+					$rules .= $links;
+					$rules .= "</IfModule>\n";
+				}
+			}
+			
+			if( !empty($rules) ){
+				file_put_contents( dirname( $path ) . '/.htaccess', $rules);
+			}
 		}
 
 		return true;

--- a/inc/options/minify.php
+++ b/inc/options/minify.php
@@ -318,9 +318,7 @@ Util_Ui::config_item( array(
         'control' => 'checkbox',
         'checkbox_label' => __( 'Enable', 'w3-total-cache' ),
         'description' => __( 'For better performance, send files to browser before they are requested when using the HTTP/2 protocol.',
-            'w3-total-cache' ) .
-            ( $this->_config->get_string( 'pgcache.engine' ) != 'file_generic' ? '' :
-                __( ' <br /><b>Not supported by "Disk: Enhanced" page cache engine</b>', 'w3-total-cache' ) )
+            'w3-total-cache' ) 
     ) ); ?>
         </table>
 
@@ -443,9 +441,7 @@ Util_Ui::config_item( array(
         'control' => 'checkbox',
         'checkbox_label' => __( 'Enable', 'w3-total-cache' ),
         'description' => __( 'For better performance, send files to browser before they are requested when using the HTTP/2 protocol.',
-            'w3-total-cache' ) .
-            ( $this->_config->get_string( 'pgcache.engine' ) != 'file_generic' ? '' :
-                __( ' <br /><b>Not supported by "Disk: Enhanced" page cache engine</b>', 'w3-total-cache' ) )
+            'w3-total-cache' )
     ) ); ?>
         </table>
 


### PR DESCRIPTION
This pr extends "http 2 push" feature to page cache enhanced.

The `Link` headers are stored in the `.htaccess` into eg. `/wp-content/cache/page_enhanced/foo-page/.htaccess` and returned into the response like memory cache modules (APCu, Redis ...), eg.:

```
<IfModule mod_headers.c>
    Header add Link '</wp-content/cache/minify/1/ebbd6.js>; rel=preload; as=script'
    Header add Link '</wp-content/cache/minify/1/63402.js>; rel=preload; as=script'
    Header add Link '</wp-content/cache/minify/1/773a9.css>; rel=preload; as=style'
</IfModule>
```

The `.htaccess` is updated on each cache purge.

~~For some technical reason, this feature works only on the first 50 headers sent (but this limit is reasonable).~~

PR https://github.com/szepeviktor/w3-total-cache-fixed/pull/450 remove all limit and push all assets.

Also requested in https://github.com/szepeviktor/w3-total-cache-fixed/issues/234
