### PR TITLE
Add referrer policy security header

### DIFF
--- a/BrowserCache_ConfigLabels.php
+++ b/BrowserCache_ConfigLabels.php
@@ -52,6 +52,8 @@ class BrowserCache_ConfigLabels {
                 'browsercache.security.pkp.extra' => __( 'Extra Parameters:', 'w3-total-cache' ),
                 'browsercache.security.pkp.report.url' => __( 'Report URL:', 'w3-total-cache' ),
                 'browsercache.security.pkp.report.only' => __( 'Report Mode Only:', 'w3-total-cache' ),
+                'browsercache.security.referrer.policy' => __( 'Referrer Policy', 'w3-total-cache' ),
+                'browsercache.security.referrer.policy.directive' => __( 'Directive:', 'w3-total-cache' ),
                 'browsercache.security.csp' => __( 'Content Security Policy', 'w3-total-cache' ),
                 'browsercache.security.csp.base' => __( 'base-uri:', 'w3-total-cache' ),
                 'browsercache.security.csp.frame' => __( 'frame-src:', 'w3-total-cache' ),

--- a/BrowserCache_Environment.php
+++ b/BrowserCache_Environment.php
@@ -344,7 +344,7 @@ class BrowserCache_Environment {
             $lifetime = $config->get_integer( 'browsercache.other.lifetime' );
 
 			$rules .= "<IfModule mod_headers.c>\n";
-            
+
             if ( $config->get_boolean( 'browsercache.security.hsts' ) ) {
                 $dir = $config->get_string( 'browsercache.security.hsts.directive' );
                 $rules .= "    Header set Strict-Transport-Security \"max-age=$lifetime" . ( strpos( $dir,"inc" ) ? "; includeSubDomains" : "" ) . ( strpos( $dir, "pre" ) ? "; preload" : "" ) . "\"\n";
@@ -362,7 +362,7 @@ class BrowserCache_Environment {
             if ( $config->get_boolean( 'browsercache.security.xss' ) ) {
                 $dir = $config->get_string( 'browsercache.security.xss.directive' );
                 $rules .= "    Header set X-XSS-Protection \"" . ( $dir == "block" ? "1; mode=block" : $dir ) . "\"\n";
-            
+
             }
 
             if ( $config->get_boolean( 'browsercache.security.xcto' ) ) {
@@ -376,6 +376,11 @@ class BrowserCache_Environment {
                 $url = trim( $config->get_string( 'browsercache.security.pkp.report.url' ) );
                 $rep_only = $config->get_string( 'browsercache.security.pkp.report.only' ) == '1' ? true : false;
                 $rules .= "    Header set " . ( $rep_only ? "Public-Key-Pins-Report-Only" : "Public-Key-Pins" ) . " \"pin-sha256=\\\"$pin\\\"; pin-sha256=\\\"$pinbak\\\"; max-age=$lifetime" . ( strpos( $extra,"inc" ) ? "; includeSubDomains" : "" ) . ( !empty( $url ) ? "; report-uri=\\\"$url\\\"" : "" ) . "\"\n";
+            }
+
+            if ( $config->get_boolean( 'browsercache.security.referrer.policy' ) ) {
+                $dir = $config->get_string( 'browsercache.security.referrer.policy.directive' );
+                $rules .= "    Header set Referrer-Policy \"" . ($dir == "0" ? "" : $dir ) . "\"\n";
             }
 
             if ( $config->get_boolean( 'browsercache.security.csp' ) ) {
@@ -413,7 +418,7 @@ class BrowserCache_Environment {
                     $rules .= "    Header set Content-Security-Policy \"$dir\"\n";
                 }
             }
-            
+
 			$rules .= "</IfModule>\n";
 		}
 
@@ -642,6 +647,7 @@ class BrowserCache_Environment {
              $config->get_boolean( 'browsercache.security.xss' )  ||
              $config->get_boolean( 'browsercache.security.xcto' ) ||
              $config->get_boolean( 'browsercache.security.pkp' )  ||
+             $config->get_boolean( 'browsercache.security.referrer.policy' )  ||
              $config->get_boolean( 'browsercache.security.csp' )
            ) {
             $lifetime = $config->get_integer( 'browsercache.other.lifetime' );
@@ -650,7 +656,7 @@ class BrowserCache_Environment {
                 $dir = $config->get_string( 'browsercache.security.hsts.directive' );
                 $rules .= "add_header Strict-Transport-Security \"max-age=$lifetime" . ( strpos( $dir,"inc" ) ? "; includeSubDomains" : "" ) . ( strpos( $dir, "pre" ) ? "; preload" : "" ) . "\";\n";
             }
-            
+
             if ( $config->get_boolean( 'browsercache.security.xfo' ) ) {
                 $dir = $config->get_string( 'browsercache.security.xfo.directive' );
                 $url = trim( $config->get_string( 'browsercache.security.xfo.allow' ) );
@@ -659,11 +665,11 @@ class BrowserCache_Environment {
                 }
                 $rules .= "add_header X-Frame-Options \"" . ( $dir == "same" ? "SAMEORIGIN" : ( $dir == "deny" ? "DENY" : "ALLOW-FROM $url" ) ) . "\";\n";
             }
-            
+
             if ( $config->get_boolean( 'browsercache.security.xss' ) ) {
                 $dir = $config->get_string( 'browsercache.security.xss.directive' );
                 $rules .= "add_header X-XSS-Protection \"" . ( $dir == "block" ? "1; mode=block" : $dir ) . "\";\n";
-            
+
             }
 
             if ( $config->get_boolean( 'browsercache.security.xcto' ) ) {
@@ -678,7 +684,12 @@ class BrowserCache_Environment {
                 $rep_only = $config->get_string( 'browsercache.security.pkp.report.only' ) == '1' ? true : false;
                 $rules .= "add_header " . ( $rep_only ? "Public-Key-Pins-Report-Only" : "Public-Key-Pins" ) . " 'pin-sha256=\"$pin\"; pin-sha256=\"$pinbak\"; max-age=$lifetime" . ( strpos( $extra,"inc" ) ? "; includeSubDomains" : "" ) . ( !empty( $url ) ? "; report-uri=\"$url\"" : "" ) . "';\n";
             }
-            
+
+            if ( $config->get_boolean( 'browsercache.security.referrer.policy' ) ) {
+                $dir = $config->get_string( 'browsercache.security.referrer.policy.directive' );
+                $rules .= "add_header Referrer-Policy \"" . ( $dir == "0" ? "" : $dir ) . "\";\n";
+            }
+
             if ( $config->get_boolean( 'browsercache.security.csp' ) ) {
                 $base = trim( $config->get_string( 'browsercache.security.csp.base' ) );
                 $frame = trim( $config->get_string( 'browsercache.security.csp.frame' ) );

--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -1639,6 +1639,14 @@ $keys = array(
         'type' => 'string',
         'default' => '0'
     ),
+    'browsercache.security.referrer.policy' => array(
+        'type' => 'boolean',
+        'default' => 'false'
+    ),
+    'browsercache.security.referrer.policy.directive' => array(
+        'type' => 'string',
+        'default' => '0'
+    ),
     'browsercache.security.csp' => array(
         'type' => 'boolean',
         'default' => false

--- a/inc/options/browsercache.php
+++ b/inc/options/browsercache.php
@@ -378,7 +378,7 @@ Util_Ui::config_item( array(
 
         <?php Util_Ui::button_config_save( 'browsercache_media' ); ?>
         <?php Util_Ui::postbox_footer(); ?>
-        
+
         <?php Util_Ui::postbox_header( __( 'Security Headers', 'w3-total-cache' ), '', 'security' ); ?>
         <p><?php _e( 'HTTP security headers provide another layer of protection for your website by helping to mitigate attacks and security vulnerabilities.', 'w3-total-cache' ); ?></p>
         <table class="form-table">
@@ -409,12 +409,12 @@ Util_Ui::config_item( array(
             <tr>
                 <th>
                     <label for="browsercache_security_hsts_directive"><?php Util_Ui::e_config_label( 'browsercache.security.hsts.directive' ) ?></label>
-                </th>			 
+                </th>
                 <td>
                     <select id="browsercache_security_hsts_directive"
                         <?php Util_Ui::sealing_disabled( 'browsercache.' ) ?>
                         name="browsercache__security__hsts__directive">
-                        <?php $value = $this->_config->get_string( 'browsercache.security.hsts.directive' ); ?>				
+                        <?php $value = $this->_config->get_string( 'browsercache.security.hsts.directive' ); ?>
                         <option value="maxage"<?php selected( $value, 'maxage' ); ?>><?php _e( 'max-age=EXPIRES_SECONDS', 'w3-total-cache' ); ?></option>
                         <option value="maxagepre"<?php selected( $value, 'maxagepre' ); ?>><?php _e( 'max-age=EXPIRES_SECONDS; preload', 'w3-total-cache' ); ?></option>
                         <option value="maxageinc"<?php selected( $value, 'maxageinc' ); ?>><?php _e( 'max-age=EXPIRES_SECONDS; includeSubDomains', 'w3-total-cache' ); ?></option>
@@ -432,7 +432,7 @@ Util_Ui::config_item( array(
             <tr>
                 <th>
                     <label for="browsercache_security_xfo_directive"><?php Util_Ui::e_config_label( 'browsercache.security.xfo.directive' ) ?></label>
-                </th>			 
+                </th>
                 <td>
                     <select id="browsercache_security_xfo_directive"
                         <?php Util_Ui::sealing_disabled( 'browsercache.' ) ?>
@@ -456,7 +456,7 @@ Util_Ui::config_item( array(
             <tr>
                 <th>
                     <label for="browsercache_security_xss_directive"><?php Util_Ui::e_config_label( 'browsercache.security.xss.directive' ) ?></label>
-                </th>			 
+                </th>
                 <td>
                     <select id="browsercache_security_xss_directive"
                         <?php Util_Ui::sealing_disabled( 'browsercache.' ) ?>
@@ -539,6 +539,33 @@ Util_Ui::config_item( array(
                         <option value="1"<?php selected( $value, '1' ); ?>><?php _e( 'Yes = Don\'t Enforce HPKP', 'w3-total-cache' ); ?></option>
                     </select>
                     <div id="browsercache_security_pkp_report_only_description"></div>
+                </td>
+            </tr>
+            <tr>
+                <th colspan="2">
+                    <?php $this->checkbox( 'browsercache.security.referrer.policy' ) ?> <?php Util_Ui::e_config_label( 'browsercache.security.referrer.policy' ) ?></label>
+                    <br /><span class="description"><?php _e( 'This header restricts the values of the referer header in outbound links.' ); ?></span>
+                </th>
+            </tr>
+            <tr>
+                <th>
+                    <label for="browsercache_security_referrer_policy_directive"><?php Util_Ui::e_config_label( 'browsercache.security.referrer.policy.directive' ) ?></label>
+                </th>
+                <td>
+                    <select id="browsercache_security_referrer_policy_directive"
+                        <?php Util_Ui::sealing_disabled( 'browsercache.' ) ?>
+                        name="browsercache__security__referrer__policy__directive">
+                        <?php $value = $this->_config->get_string( 'browsercache.security.referrer.policy.directive' ); ?>
+                        <option value="0"<?php selected( $value, '0' ); ?>><?php _e( '""', 'w3-total-cache' ); ?></option>
+                        <option value="no-referrer"<?php selected( $value, 'no-referrer' ); ?>><?php _e( 'no-referrer', 'w3-total-cache' ); ?></option>
+                        <option value="no-referrer-when-downgrade"<?php selected( $value, 'no-referrer-when-downgrade' ); ?>><?php _e( 'no-referrer-when-downgrade', 'w3-total-cache' ); ?></option>
+                        <option value="same-origin"<?php selected( $value, 'same-origin' ); ?>><?php _e( 'same-origin', 'w3-total-cache' ); ?></option>
+                        <option value="origin"<?php selected( $value, 'origin' ); ?>><?php _e( 'origin', 'w3-total-cache' ); ?></option>
+                        <option value="strict-origin"<?php selected( $value, 'strict-origin' ); ?>><?php _e( 'strict-origin', 'w3-total-cache' ); ?></option>
+                        <option value="origin-when-cross-origin"<?php selected( $value, 'origin-when-cross-origin' ); ?>><?php _e( 'origin-when-cross-origin', 'w3-total-cache' ); ?></option>
+                        <option value="unsafe-url"<?php selected( $value, 'unsafe-url' ); ?>><?php _e( 'unsafe-url', 'w3-total-cache' ); ?></option>
+                    </select>
+                    <div id="browsercache_security_referrer_policy_directive_description"></div>
                 </td>
             </tr>
             <tr>

--- a/pub/js/options.js
+++ b/pub/js/options.js
@@ -392,8 +392,8 @@ function w3tc_starts_with(s, starts_with) {
 }
 
 function w3tc_security_headers() {
-    var directive_description = 
-        { 
+    var directive_description =
+        {
             browsercache_security_hsts_directive:
             {
                 maxage: 'The time, in seconds (as defined under the "Expires Header Lifetime" box of "Media & Other Files"), that the browser should remember that this site is only to be accessed using HTTPS. This only affects the site\'s main domain.',
@@ -422,10 +422,22 @@ function w3tc_security_headers() {
             {
                 0: 'This instructs the browser to enforce the HPKP policy.',
                 1: 'This sets up HPKP without enforcement allowing you to use pinning to test its impact without the risk of a failed connection caused by your site being unreachable or HPKP being misconfigured.'
+            },
+            browsercache_security_referrer_policy_directive:
+            {
+                0: 'This instructs the browser to fallback to a Referrer Policy defined via other mechanisms. This has no impact but confirms that the site has intentionally omitted it.',
+                'no-referrer': 'This instructs the browser to never send the referer header with requests that are made from your site, including request on this site.',
+                'no-referrer-when-downgrade': 'This instructs the browser to not send the referrer header when navigating from HTTPS to HTTP, but always send the full URL in the referrer header when navigating from HTTP to any origin. It doesn\'t matter whether the source and destination are the same site or not, only the scheme.',
+                'same-origin': 'This instructs the browser to only set the referrer header on requests to the same origin. If the destination is another origin then no referrer information will be sent.',
+                'origin': 'This instructs the browser to always set the referrer header to the origin from which the request was made. This will strip any path information from the referrer information.',
+                'strict-origin': 'This instructs the browser to always set the referrer header to the origin from which the request was made. This will strip any path information from the referrer information. Will not allow the secure origin to be sent on a HTTP request, only HTTPS.',
+                'origin-when-cross-origin': 'This instructs the browser to send the full URL to requests to the same origin but only send the origin when requests are cross-origin.',
+                'strict-origin-when-cross-origin': 'This instructs the browser to send the full URL to requests to the same origin but only send the origin when requests are cross-origin. Will not allow any information to be sent when a scheme downgrade happens (the user is navigating from HTTPS to HTTP).',
+                'unsafe-url': 'The browser will always send the full URL with any request to any origin.',
             }
         };
 
-    jQuery('#browsercache_security_hsts_directive,#browsercache_security_xfo_directive,#browsercache_security_xss_directive,#browsercache_security_pkp_extra,#browsercache_security_pkp_report_only').change(
+    jQuery('#browsercache_security_hsts_directive,#browsercache_security_xfo_directive,#browsercache_security_xss_directive,#browsercache_security_pkp_extra,#browsercache_security_pkp_report_only,#browsercache_security_referrer_policy_directive').change(
     function() {
         jQuery('#' + jQuery(this).attr('id') + '_description').html('<i>' + directive_description[jQuery(this).attr('id')][jQuery(this).val()] + '</i>');
             if (jQuery(this).attr('id') == 'browsercache_security_xfo_directive') {
@@ -443,7 +455,7 @@ function w3tc_security_headers() {
         } else {
             jQuery('#browsercache_security_xfo_allow').hide();
         }
-        jQuery('#browsercache_security_hsts_directive,#browsercache_security_xfo_directive,#browsercache_security_xss_directive,#browsercache_security_pkp_extra,#browsercache_security_pkp_report_only').change();
+        jQuery('#browsercache_security_hsts_directive,#browsercache_security_xfo_directive,#browsercache_security_xss_directive,#browsercache_security_pkp_extra,#browsercache_security_pkp_report_only,#browsercache_security_referrer_policy_directive').change();
     }
 }
 
@@ -536,7 +548,7 @@ jQuery(function() {
         ['browsercache__cssjs__replace', 'browsercache__other__replace']);
     w3tc_toggle2('browsercache_nocookies',
         ['browsercache__cssjs__nocookies', 'browsercache__other__nocookies']);
-    
+
     w3tc_security_headers();
 
     // minify page
@@ -760,10 +772,10 @@ jQuery(function() {
       var metadata = me.metadata();
       w3tc_use_poll_zone(metadata.type, metadata.nonce);
     });
-    
+
     jQuery('#cdn_s3_bucket,#cdn_cf_bucket').focusout(function () {
       jQuery(this).val(jQuery(this).val().toLowerCase());
-    });    
+    });
 
     jQuery('#cdn_test').click(function() {
         var me = jQuery(this);
@@ -972,7 +984,7 @@ jQuery(function() {
         status.removeClass('w3tc-error');
         status.removeClass('w3tc-success');
         status.addClass('w3tc-process');
-        
+
         var status2 = jQuery('#cdn_create_container_status');
         status2.removeClass('w3tc-error');
         status2.removeClass('w3tc-success');
@@ -1084,7 +1096,7 @@ jQuery(function() {
         var status2 = jQuery('#cdn_test_status');
         status2.removeClass('w3tc-error');
         status2.removeClass('w3tc-success');
-        status2.html('');            
+        status2.html('');
 
         status.html('Creating...');
 


### PR DESCRIPTION
This PR closes #435 
It allows for setting the `Referrer-Policy` security header.

I've tried to follow the code style, let me know if I missed anything.

I've cleaned some trailing white spaces in the edited files. I would recommend that you did this on all files on wards, just to keep the diffs cleaner. Mist IDEs and editors have the options of doing it automatically.

Thank you for a great "fixed" plugin. This effectively fixed my needs for additional configuration and modification when setting the security headers.