### PR TITLE
Fix for Object Cache 'Get' method incorrectly setting cache value

### DIFF
--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -191,10 +191,10 @@ class ObjectCache_WpObjectCache_Regular {
 			$found = ( $value !== false );
 		}
 
-		$this->cache[$key] = $value;
 		$this->cache_total++;
 
 		if ( $value !== false ) {
+			$this->cache[$key] = $value;
 			$this->cache_hits++;
 		} else {
 			$this->cache_misses++;

--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ Type | More Information |
 :beetle: Bug Fix | [Closure Compiler fix for JAVA path](https://github.com/szepeviktor/w3-total-cache-fixed/pull/428) |
 :beetle: Bug Fix | [Fixed Redis Test on Admin Dashboard](https://github.com/szepeviktor/w3-total-cache-fixed/pull/430) |
 :cyclone: New Feature | [Extends "http 2 push" to page cache enhanced](https://github.com/szepeviktor/w3-total-cache-fixed/pull/433) |
+:beetle: Bug Fix | [Fixed Object Cache setting cache value on missed gets](https://github.com/szepeviktor/w3-total-cache-fixed/issues/438) |


### PR DESCRIPTION
This PR is for issue #438 wherein `wp_cache_get` shows `$found` to be `true` even it is directly preceded by a`wp_cache_delete`.

The issue lies in the `get` function in `ObjectCache_WpObjectCache_Regular.php `, which always sets a value for the cache object's key, even if a hit was not found.

The proposed fix is to only set `$this->cache[$key] = $value;` if `$value !== false`