### PR TITLE
Call to a member function using_index_permalinks() on null

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ Type | More Information |
 :beetle: Bug Fix | [Fixed Redis Test on Admin Dashboard](https://github.com/szepeviktor/w3-total-cache-fixed/pull/430) |
 :cyclone: New Feature | [Extends "http 2 push" to page cache enhanced](https://github.com/szepeviktor/w3-total-cache-fixed/pull/433) |
 :beetle: Bug Fix | [Fixed Object Cache setting cache value on missed gets](https://github.com/szepeviktor/w3-total-cache-fixed/issues/438) |
+:beetle: Bug Fix | [Call to a member function using_index_permalinks() on null](https://github.com/szepeviktor/w3-total-cache-fixed/issues/445) |

--- a/Util_PageUrls.php
+++ b/Util_PageUrls.php
@@ -510,7 +510,7 @@ class Util_PageUrls {
 
 		$base = trailingslashit( get_bloginfo( 'url' ) );
 
-		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) )
+		if ( !is_null($wp_rewrite) && $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) )
 			$base .= 'index.php/';
 
 		if ( $pagenum > 1 ) {


### PR DESCRIPTION
From official forum https://wordpress.org/support/topic/fatal-error-util_pageurls-php/

> Fatal error: Call to a member function using_index_permalinks() on null in /data/www/14157/kosmonautix_cz/wp-content/plugins/w3-total-cache/Util_PageUrls.php on line 503

w3tc doesn't check if `global $wp_rewrite;`is initialized:

```php
if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) )
    $base .= 'index.php/';
```

My fix is a simple check

```php
if ( !is_null($wp_rewrite) && $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) )
    $base .= 'index.php/';
```
