### PR TITLE
PHP Warning: stristr(): Empty needle

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ Type | More Information |
 :cyclone: New Feature | [Extends "http 2 push" to page cache enhanced](https://github.com/szepeviktor/w3-total-cache-fixed/pull/433) |
 :beetle: Bug Fix | [Fixed Object Cache setting cache value on missed gets](https://github.com/szepeviktor/w3-total-cache-fixed/issues/438) |
 :beetle: Bug Fix | [Call to a member function using_index_permalinks() on null](https://github.com/szepeviktor/w3-total-cache-fixed/issues/445) |
+:beetle: Bug Fix | [stristr(): Empty needle](https://github.com/szepeviktor/w3-total-cache-fixed/issues/447) |

--- a/lib/Minify/Minify/HTML.php
+++ b/lib/Minify/Minify/HTML.php
@@ -184,7 +184,7 @@ class Minify_HTML {
     protected function _ignoredComment($comment)
     {
         foreach ($this->_ignoredComments as $ignoredComment) {
-            if (stristr($comment, $ignoredComment) !== false) {
+            if ( !empty($ignoredComment) && stristr($comment, $ignoredComment) !== false) {
                 return true;
             }
         }

--- a/lib/Minify/Minify/IgnoredCommentPreserver.php
+++ b/lib/Minify/Minify/IgnoredCommentPreserver.php
@@ -39,7 +39,7 @@ class Minify_IgnoredCommentPreserver {
 
     protected function _isIgnoredComment(&$comment) {
         foreach ($this->_ignoredComments as $ignoredComment) {
-            if (stristr($comment, $ignoredComment) !== false) {
+            if ( !empty($ignoredComment) && stristr($comment, $ignoredComment) !== false) {
                 return true;
             }
         }


### PR DESCRIPTION
From forum https://wordpress.org/support/topic/php-warning-stristr-empty-needle-2/

> PHP Warning: stristr(): Empty needle in /home/user/public_html/wp-content/plugins/w3-total-cache/lib/Minify/Minify/IgnoredCommentPreserver.php on line 42, referer: https://www.google.com/

and

`stristr(): Empty needle in /home/user/public_html/wp-content/plugins/w3-total-cache/lib/Minify/Minify/HTML.php on line 187`

in both cases w3tc doesn't check empty needle in stristr:

```php
if ( stristr($comment, $ignoredComment) !== false) {
    return true;
}
```

my fix is a simple check for non empty needle:

```php
if ( !empty($ignoredComment) && stristr($comment, $ignoredComment) !== false) {
    return true;
}
```