### PR TITLE
http2 push: Support for more than 50 assets

### DIFF
--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -100,19 +100,18 @@ class Cache_File_Generic extends Cache_File {
 			if( isset($var['headers'][0]) ){
 				
 				$links = '';
+				$i = 0;
 				
-				for($i = 0; $i < 100; $i++){
-					
-					if( !isset($var['headers'][$i]) ){
-						break;
-					}
+				while( isset($var['headers'][$i]) ){
 					
 					$name  = isset($var['headers'][$i]['n']) ? $var['headers'][$i]['n'] : '';
 					$value = isset($var['headers'][$i]['v']) ? $var['headers'][$i]['v'] : '';
 					
 					if( ($name == 'Link') && (false !== strpos($value, 'rel=preload')) ){
-						$links .= "    Header add Link '".trim($var['headers'][$i]['v'])."'\n";
+						$links .= "    Header add Link '".trim($value)."'\n";
 					}
+					
+					$i++;
 				}
 				
 				if( !empty($links) ){

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Type | More Information |
 :beetle: Bug Fix | [YUI Compressor fix for JAVA path](https://github.com/szepeviktor/w3-total-cache-fixed/pull/426) |
 :beetle: Bug Fix | [Closure Compiler fix for JAVA path](https://github.com/szepeviktor/w3-total-cache-fixed/pull/428) |
 :beetle: Bug Fix | [Fixed Redis Test on Admin Dashboard](https://github.com/szepeviktor/w3-total-cache-fixed/pull/430) |
-:cyclone: New Feature | [Extends "http 2 push" to page cache enhanced](https://github.com/szepeviktor/w3-total-cache-fixed/pull/433) |
+:cyclone: New Feature | [Extends "http 2 push" to page cache enhanced](https://github.com/szepeviktor/w3-total-cache-fixed/pull/433)<br>:wrench: [+ **Extra: #PR320** &ndash; Support for more than 50 assets](https://github.com/szepeviktor/w3-total-cache-fixed/pull/450) |
 :beetle: Bug Fix | [Fixed Object Cache setting cache value on missed gets](https://github.com/szepeviktor/w3-total-cache-fixed/issues/438) |
 :beetle: Bug Fix | [Call to a member function using_index_permalinks() on null](https://github.com/szepeviktor/w3-total-cache-fixed/issues/445) |
 :beetle: Bug Fix | [stristr(): Empty needle](https://github.com/szepeviktor/w3-total-cache-fixed/issues/447) |


### PR DESCRIPTION
PR https://github.com/szepeviktor/w3-total-cache-fixed/pull/433 extend http2 push for disk enhanced, but works only for max 50 assets to push. This pr remove all limit and push all assets.