### PR TITLE
Media Library Export skips files

### DIFF
--- a/CdnEngine_Azure.php
+++ b/CdnEngine_Azure.php
@@ -27,7 +27,7 @@ class CdnEngine_Azure extends CdnEngine_Base {
 
 		parent::__construct( $config );
 
-		require_once W3TC_LIB_DIR . DIRECTORY_SEPARATOR . 'Azure' . 
+		require_once W3TC_LIB_DIR . DIRECTORY_SEPARATOR . 'Azure' .
 			DIRECTORY_SEPARATOR . 'loader.php';
 	}
 
@@ -66,7 +66,7 @@ class CdnEngine_Azure extends CdnEngine_Base {
 			$error = $ex->getMessage();
 			return false;
 		}
-		
+
 
 		return true;
 	}
@@ -90,10 +90,14 @@ class CdnEngine_Azure extends CdnEngine_Base {
 		}
 
 		foreach ( $files as $file ) {
-			if ( !is_null( $timeout_time ) && time() > $timeout_time )
-				break;
-
 			$remote_path = $file['remote_path'];
+			$local_path = $file['local_path'];
+
+			if ( !is_null( $timeout_time ) && time() > $timeout_time ) {
+				$results[] = $this->_get_result( $local_path, $remote_path,
+					W3TC_CDN_RESULT_ERROR, "Upload batch timed out.", $file );
+				continue;
+			}
 
 			$results[] = $this->_upload( $file, $force_rewrite );
 		}

--- a/CdnEngine_Ftp.php
+++ b/CdnEngine_Ftp.php
@@ -164,11 +164,14 @@ class CdnEngine_Ftp extends CdnEngine_Base {
 		}
 
 		foreach ( $files as $file ) {
-			if ( !is_null( $timeout_time ) && time() > $timeout_time )
-				break;
-
-			$local_path = $file['local_path'];
 			$remote_path = $file['remote_path'];
+			$local_path = $file['local_path'];
+
+			if ( !is_null( $timeout_time ) && time() > $timeout_time ) {
+				$results[] = $this->_get_result( $local_path, $remote_path,
+					W3TC_CDN_RESULT_ERROR, "Upload batch timed out.", $file );
+				continue;
+			}
 
 			if ( !file_exists( $local_path ) ) {
 				$results[] = $this->_get_result( $local_path, $remote_path,

--- a/CdnEngine_GoogleDrive.php
+++ b/CdnEngine_GoogleDrive.php
@@ -79,7 +79,7 @@ class CdnEngine_GoogleDrive extends CdnEngine_Base {
 	function upload( $files, &$results, $force_rewrite = false, $timeout_time = NULL ) {
 		if ( is_null( $this->_service ) )
 			return false;
-		
+
 		$allow_refresh_token = true;
 		$result = true;
 
@@ -96,8 +96,13 @@ class CdnEngine_GoogleDrive extends CdnEngine_Base {
 			}
 			if ( $r != 'success' )
 				$result = false;
-			if ( $r == 'timeout' )
-				break;
+			if ( $r == 'timeout' ) {
+				$results = array_merge( $results, $this->_get_results(
+					$files_chunk, W3TC_CDN_RESULT_ERROR,
+					"Upload batch timed out." );
+				continue;
+			}
+
 		}
 
 		return $result;

--- a/CdnEngine_RackSpaceCloudFiles.php
+++ b/CdnEngine_RackSpaceCloudFiles.php
@@ -145,11 +145,14 @@ class CdnEngine_RackSpaceCloudFiles extends CdnEngine_Base {
 	function upload( $files, &$results, $force_rewrite = false,
 		$timeout_time = NULL ) {
 		foreach ( $files as $file ) {
-			if ( !is_null( $timeout_time ) && time() > $timeout_time )
-				break;
-
-			$local_path = $file['local_path'];
 			$remote_path = $file['remote_path'];
+			$local_path = $file['local_path'];
+
+			if ( !is_null( $timeout_time ) && time() > $timeout_time ) {
+				$results[] = $this->_get_result( $local_path, $remote_path,
+					W3TC_CDN_RESULT_ERROR, "Upload batch timed out.", $file );
+				continue;
+			}
 
 			if ( !file_exists( $local_path ) ) {
 				$results[] = $this->_get_result( $local_path, $remote_path,

--- a/CdnEngine_S3.php
+++ b/CdnEngine_S3.php
@@ -120,11 +120,14 @@ class CdnEngine_S3 extends CdnEngine_Base {
 		}
 
 		foreach ( $files as $file ) {
-			if ( !is_null( $timeout_time ) && time() > $timeout_time )
-				break;
-
-			$local_path = $file['local_path'];
 			$remote_path = $file['remote_path'];
+			$local_path = $file['local_path'];
+
+			if ( !is_null( $timeout_time ) && time() > $timeout_time ) {
+				$results[] = $this->_get_result( $local_path, $remote_path,
+					W3TC_CDN_RESULT_ERROR, "Upload batch timed out.", $file );
+				continue;
+			}
 
 			$results[] = $this->_upload( $file, $force_rewrite );
 

--- a/CdnEngine_S3_Compatible.php
+++ b/CdnEngine_S3_Compatible.php
@@ -75,11 +75,14 @@ class CdnEngine_S3_Compatible extends CdnEngine_Base {
 		$error = null;
 
 		foreach ( $files as $file ) {
-			if ( !is_null( $timeout_time ) && time() > $timeout_time )
-				break;
-
-			$local_path = $file['local_path'];
 			$remote_path = $file['remote_path'];
+			$local_path = $file['local_path'];
+
+			if ( !is_null( $timeout_time ) && time() > $timeout_time ) {
+				$results[] = $this->_get_result( $local_path, $remote_path,
+					W3TC_CDN_RESULT_ERROR, "Upload batch timed out.", $file );
+				continue;
+			}
 
 			$results[] = $this->_upload( $file, $force_rewrite );
 

--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -118,7 +118,7 @@ class Cdn_AdminActions {
 		$results = array();
 
 		$w3_plugin_cdn->export_library( $limit, $offset, $count, $total,
-			$results, time() + 5 );
+			$results, time() + 120 );
 
 		$response = array(
 			'limit' => $limit,

--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -123,7 +123,7 @@ class Cdn_AdminActions {
 		$response = array(
 			'limit' => $limit,
 			'offset' => $offset,
-			'count' => count( $results ),
+			'count' => $count,
 			'total' => $total,
 			'results' => $results
 		);

--- a/Cdn_Core_Admin.php
+++ b/Cdn_Core_Admin.php
@@ -209,7 +209,9 @@ class Cdn_Core_Admin {
             WHERE
                 p.post_type = "attachment"  AND (pm.meta_value IS NOT NULL OR pm2.meta_value IS NOT NULL)
             GROUP BY
-            	p.ID', $wpdb->prefix, $wpdb->prefix, $wpdb->prefix );
+            	p.ID
+			ORDER BY
+				p.ID', $wpdb->prefix, $wpdb->prefix, $wpdb->prefix );
 
 			if ( $limit ) {
 				$sql .= sprintf( ' LIMIT %d', $limit );


### PR DESCRIPTION
- Webserver: Apache running on AWS Elastic Beanstalk
- PHP version: 7.0 mod_php
- Database server: MariaDB 10.0
- WordPress core: 4.7.3
- W3 Total Cache plugin: 0.9.5.2.3

On a large site we ran the Media Library Exporter and noticed that many files were being skipped. After digging through the code I discovered several issues with the export_library process.

1. It uses a LIMIT,OFFSET clause without ORDER BY. This is not stable and the database can return expected rows or skip rows.

2. It improperly calculates the next offset value.

3. It only gives the upload process 5 seconds per batch. This is not enough time for large media libraries.

I will submit a pull request fixing these issues. This appears to have solved our media library export problem. I haven't had the resources to test modifications to some of the CdnEngines, but S3 seems to be working.

Fixes #451