### PR TITLE
handle xml option always disabled on nginex 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Type | More Information |
 :beetle: Bug Fix | [WP Query String Being Stripped Unexpectedly](https://github.com/szepeviktor/w3-total-cache-fixed/pull/384) |
 :cyclone: New Feature | [Filter to Set Cache Lifetime Period On A Per-Page Basis](https://github.com/szepeviktor/w3-total-cache-fixed/pull/388) |
 :beetle: Bug Fix | [Warning: _Invalid Arguments in Minify_Environment.php_](https://github.com/szepeviktor/w3-total-cache-fixed/pull/389) |
-:beetle: Bug Fix | [Feeds Not Caching Nor Serving Back as XML](https://github.com/szepeviktor/w3-total-cache-fixed/pull/393) |
+:beetle: Bug Fix | [Feeds Not Caching Nor Serving Back as XML](https://github.com/szepeviktor/w3-total-cache-fixed/pull/393)<br>:wrench: [+ **Extra: &ndash; Fix admin setting always disabled on nginx](https://github.com/szepeviktor/w3-total-cache-fixed/pull/454) |
 :diamond_shape_with_a_dot_inside: Update | [Smart Browser Cache Default Settings](https://github.com/szepeviktor/w3-total-cache-fixed/pull/394)<br>:wrench: [+ **Extra: #PR395** &ndash; A Few More Useful Smart Default Settings](https://github.com/szepeviktor/w3-total-cache-fixed/pull/395) |
 :diamond_shape_with_a_dot_inside: Update | [Expanded Regex Support & Improved Page Cache Cookies](https://github.com/szepeviktor/w3-total-cache-fixed/pull/398) |
 :beetle: Bug Fix | [Debug Mode Not Working](https://github.com/szepeviktor/w3-total-cache-fixed/pull/405)<br>:wrench: [+ **Extra: #PR406** &ndash; Missed File - Debug Mode Not Working](https://github.com/szepeviktor/w3-total-cache-fixed/pull/406) |

--- a/inc/options/pgcache.php
+++ b/inc/options/pgcache.php
@@ -438,11 +438,19 @@ echo sprintf(
 			</tr>
 			<?php if ( $this->_config->get_string( 'pgcache.engine' ) == 'file_generic' ): ?>
 			<tr>
-				<th><label><?php Util_Ui::e_config_label(Util_Environment::is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml') ?></label></th>
+				<?php if( Util_Environment::is_nginx() ): ?>
+				<th><label><?php Util_Ui::e_config_label('pgcache.cache.nginx_handle_xml') ?></label></th>
 				<td>
-					<?php $this->checkbox(Util_Environment::is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml', Util_Environment::is_nginx()?true:false) ?> <?php Util_Ui::e_config_label(Util_Environment::is_nginx()?'pgcache.cache.nginx_handle_xml':'pgcache.cache.apache_handle_xml') ?></label><br />
+					<?php $this->checkbox('pgcache.cache.nginx_handle_xml') ?> <?php Util_Ui::e_config_label('pgcache.cache.nginx_handle_xml') ?><br />
 					<span class="description"><?php _e( 'Return correct Content-Type header for XML files (e.g., feeds and sitemaps). Slows down cache engine.', 'w3-total-cache' ); ?></span>
 				</td>
+				<?php else: ?>
+				<th><label><?php Util_Ui::e_config_label('pgcache.cache.apache_handle_xml') ?></label></th>
+				<td>
+					<?php $this->checkbox('pgcache.cache.apache_handle_xml') ?> <?php Util_Ui::e_config_label('pgcache.cache.apache_handle_xml') ?></label><br />
+					<span class="description"><?php _e( 'Return correct Content-Type header for XML files (e.g., feeds and sitemaps). Slows down cache engine.', 'w3-total-cache' ); ?></span>
+				</td>
+				<?php endif; ?>
 			</tr>
 			<?php endif; ?>
 		</table>


### PR DESCRIPTION
related to #393 and partial fix for https://github.com/szepeviktor/w3-total-cache-fixed/issues/449 (fix option disabled but don't fix the content type returned).

PR #393 introduce _handle xml_ feature for caching feed and return the cache in the right content type, but this option is always disabled on nginex.

My pr make a very small refractoring of @amiga-500's work and fix the issue