### PR TITLE
Fixed semicolon bug & added woff2

### DIFF
--- a/ConfigKeys.php
+++ b/ConfigKeys.php
@@ -967,7 +967,7 @@ $keys = array(
 	),
 	'cdn.theme.files' => array(
 		'type' => 'string',
-		'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf,*.woff,*.less'
+		'default' => '*.css;*.js;*.gif;*.png;*.jpg;*.ico;*.ttf;*.otf;*.woff;*.woff2;*.less'
 	),
 	'cdn.minify.enable' => array(
 		'type' => 'boolean',


### PR DESCRIPTION
CDN upload was not working for .woff and .less files, because it was separated with a comma instead of a semicolon.
Additionally I would add .woff2 to the theme upload list.
