### PR TITLE
Fix overwriting Redis connection when using pconnect

### DIFF
--- a/Cache_Redis.php
+++ b/Cache_Redis.php
@@ -13,6 +13,7 @@ class Cache_Redis extends Cache_Base {
 	private $_servers;
 	private $_dbid;
 
+	private $_instance_key;
 	/**
 	 * constructor
 	 *
@@ -25,6 +26,7 @@ class Cache_Redis extends Cache_Base {
 		$this->_servers = (array)$config['servers'];
 		$this->_password = $config['password'];
 		$this->_dbid = $config['dbid'];
+		$this->_instance_key = sprintf( '%s_%s', 'redis', md5( serialize( $config ) ) );
 	}
 
 	/**
@@ -332,7 +334,7 @@ class Cache_Redis extends Cache_Base {
 					list( $ip, $port ) = explode( ':', $server );
 
 					if ( $this->_persistent )
-						$accessor->pconnect( trim( $ip ), (integer) trim( $port ) );
+						$accessor->pconnect( trim( $ip ), (integer) trim( $port ), null, $this->_instance_key );
 					else
 						$accessor->connect( trim( $ip ), (integer) trim( $port ) );
 				}

--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ Type | More Information |
 :beetle: Bug Fix | [Media Library Export skips files](https://github.com/szepeviktor/w3-total-cache-fixed/pull/452) |
 :beetle: Bug Fix | [Fixed semicolon bug & added woff2](https://github.com/szepeviktor/w3-total-cache-fixed/pull/457) |
 :diamond_shape_with_a_dot_inside: Update | [Colored self test window](https://github.com/szepeviktor/w3-total-cache-fixed/pull/478) |
+:beetle: Bug Fix | [Fixed Redis DB selection in persistent connection mode](https://github.com/szepeviktor/w3-total-cache-fixed/pull/483) |


### PR DESCRIPTION
This PR fixes #482

When using persistent connection with Redis and setting different DB's for the different caches, only one DB is actually used, leading to caching problems (such as page caching not working).

This is solved by adding a "persistent_id" to each connection based on the cache engine configurations.