### PR TITLE
Fixed wrong == in ObjectCache_WpObjectCache_Regular.php

### DIFF
--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -540,7 +540,7 @@ class ObjectCache_WpObjectCache_Regular {
 			if ( ! isset( $value ) )
 				$value = get_site_option( $transient_option );
 		} else {
-			$value == false;
+			$value = false;
 		}
 
 		return $value;

--- a/README.md
+++ b/README.md
@@ -89,3 +89,4 @@ Type | More Information |
 :beetle: Bug Fix | [Fixed semicolon bug & added woff2](https://github.com/szepeviktor/w3-total-cache-fixed/pull/457) |
 :diamond_shape_with_a_dot_inside: Update | [Colored self test window](https://github.com/szepeviktor/w3-total-cache-fixed/pull/478) |
 :beetle: Bug Fix | [Fixed Redis DB selection in persistent connection mode](https://github.com/szepeviktor/w3-total-cache-fixed/pull/483) |
+:beetle: Bug Fix | [Fixed wrong == in ObjectCache_WpObjectCache_Regular.php](https://github.com/szepeviktor/w3-total-cache-fixed/pull/486) |


### PR DESCRIPTION
The bug is into the function `_transient_fallback_get()` in `ObjectCache_WpObjectCache_Regular` class, sometime return a wrong `$value` becase there is a typo:
```php
} else {
    $value == false; 
}

return $value;
```

instead of 

```php
} else {
    $value = false;
}

return $value;
```

It's just a typo, the double `==` is a [comparison operators](http://php.net/manual/en/language.operators.comparison.php), but the original intention of the developer is use a single `=` for [assignment operators](http://php.net/manual/en/language.operators.assignment.php).

Thanks to @Furniel for fixed wrong `==` in `ObjectCache_WpObjectCache_Regular.php` in https://github.com/szepeviktor/w3-total-cache-fixed/pull/477