### PR TITLE
Missing commas in Generic_Page_Dashboard_View.css

### DIFF
--- a/Generic_Page_Dashboard_View.css
+++ b/Generic_Page_Dashboard_View.css
@@ -32,15 +32,15 @@
 #w3tc-dashboard-widgets div.postbox,
 #w3tc-dashboard-widgets #postbox-container-3 .hndle,
 #w3tc-dashboard-widgets #postbox-container-3 .inside,
-#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables
-#w3tc-dashboard-widgets #postbox-container-3 .widefat{
+#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables,
+#w3tc-dashboard-widgets #postbox-container-3 .widefat {
     background: none;
 }
 #w3tc-dashboard-widgets #postbox-container-3 .postbox,
 #w3tc-dashboard-widgets #postbox-container-3 .hndle,
 #w3tc-dashboard-widgets #postbox-container-3 .inside,
-#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables
-#w3tc-dashboard-widgets #postbox-container-3 .widefat{
+#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables,
+#w3tc-dashboard-widgets #postbox-container-3 .widefat {
     border:none;
 }
 #w3tc-dashboard-widgets {

--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ Type | More Information |
 :diamond_shape_with_a_dot_inside: Update | [Colored self test window](https://github.com/szepeviktor/w3-total-cache-fixed/pull/478) |
 :beetle: Bug Fix | [Fixed Redis DB selection in persistent connection mode](https://github.com/szepeviktor/w3-total-cache-fixed/pull/483) |
 :beetle: Bug Fix | [Fixed wrong == in ObjectCache_WpObjectCache_Regular.php](https://github.com/szepeviktor/w3-total-cache-fixed/pull/486) |
+:beetle: Bug Fix | [Missing commas in Generic_Page_Dashboard_View.css](https://github.com/szepeviktor/w3-total-cache-fixed/pull/487) |


### PR DESCRIPTION
in `Generic_Page_Dashboard_View.css` there are missing commas, eg. see the line `#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables`:

```css 
#w3tc-dashboard-widgets div.postbox,
#w3tc-dashboard-widgets #postbox-container-3 .hndle,
#w3tc-dashboard-widgets #postbox-container-3 .inside,
#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables
#w3tc-dashboard-widgets #postbox-container-3 .widefat{
    background: none;
}
```

this cause the css rule to become 

```css 
#w3tc-dashboard-widgets div.postbox,
#w3tc-dashboard-widgets #postbox-container-3 .hndle,
#w3tc-dashboard-widgets #postbox-container-3 .inside,
#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables #w3tc-dashboard-widgets #postbox-container-3 .widefat{
    background: none;
}
```

and does not match in the DOM the element that try to apply the style.

Add a commas at the end fix the issue, eg.:

```css 
#w3tc-dashboard-widgets div.postbox,
#w3tc-dashboard-widgets #postbox-container-3 .hndle,
#w3tc-dashboard-widgets #postbox-container-3 .inside,
#w3tc-dashboard-widgets #postbox-container-3 .meta-box-sortables,
#w3tc-dashboard-widgets #postbox-container-3 .widefat{
    background: none;
}
```

Thanks to @Furniel for fix the issue in https://github.com/szepeviktor/w3-total-cache-fixed/pull/477