### PR TITLE
Remove uninitialized var

### DIFF
--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -774,7 +774,7 @@ class Cdn_Plugin {
         static $allowed_files = null;
 
 		if ( ( defined( 'WP_ADMIN' ) && $this->_config->get_boolean( 'cdn.admin.media_library' ) ) ||
-			 ( $this->can_cdn() && $this->can_cdn2( $empty ) ) ) {
+			 ( $this->can_cdn() && $this->can_cdn2( '' ) ) ) {
 			$url = trim( $url );
 
 			if ( !empty( $url ) ) {

--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ Type | More Information |
 :beetle: Bug Fix | [Fixed Redis DB selection in persistent connection mode](https://github.com/szepeviktor/w3-total-cache-fixed/pull/483) |
 :beetle: Bug Fix | [Fixed wrong == in ObjectCache_WpObjectCache_Regular.php](https://github.com/szepeviktor/w3-total-cache-fixed/pull/486) |
 :beetle: Bug Fix | [Missing commas in Generic_Page_Dashboard_View.css](https://github.com/szepeviktor/w3-total-cache-fixed/pull/487) |
+:beetle: Bug Fix | [Remove uninitialized variable](https://github.com/szepeviktor/w3-total-cache-fixed/pull/488) |


### PR DESCRIPTION
Into `Cdn_Plugin.php` there is a uninitialized variable `$empty`, see:
```php
( $this->can_cdn() && $this->can_cdn2( $empty ) ) ) {
```

this cause an error:

> Notice: Undefined variable: $empty in Cdn_Plugin.php on line 777

the fix is replace `$empty` with an _empty string_:
```php
( $this->can_cdn() && $this->can_cdn2( '' ) ) ) {
```

This PR fix the issue https://github.com/szepeviktor/w3-total-cache-fixed/issues/470

Thanks to @Furniel for the fix in https://github.com/szepeviktor/w3-total-cache-fixed/pull/477