### PR TITLE
Fix all querystring keys starting with name specified will match

### DIFF
--- a/PgCache_ContentGrabber.php
+++ b/PgCache_ContentGrabber.php
@@ -1754,10 +1754,14 @@ class PgCache_ContentGrabber {
     private function _check_query_string() {
         $accept_qs = $this->_config->get_array( 'pgcache.accept.qs' );
         Util_Rule::array_trim( $accept_qs );
+        
+        if( empty($accept_qs) ){
+        	return false;
+        }
 
         foreach ( $accept_qs as &$val ) {
             $val = Util_Environment::preg_quote( str_replace( "+", " ", $val ) );
-            $val .=  ( strpos( $val, '=' ) === false ? '.*?' : '' );
+            $val .= ( strpos( $val, '=' ) === false ? '=.*?' : '' );
         }
 
         $accept_qs = implode( '|', $accept_qs );

--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -609,7 +609,7 @@ class PgCache_Environment {
            $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%{QUERY_STRING}]\n";
 
            foreach ( $w3tc_query_strings as $query ) {
-               $query .=  ( strpos( $query, '=' ) === false ? '.*?' : '' );
+               $query .=  ( strpos( $query, '=' ) === false ? '=.*?' : '' );
                $rules .= "    RewriteCond %{ENV:W3TC_QUERY_STRING} ^(.*?&|)".$query."(&.*|)$ [NC]\n";
                $rules .= "    RewriteRule ^ - [E=W3TC_QUERY_STRING:%1%2]\n";
            }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Type | More Information |
 :beetle: Bug Fix | [Configuration Bug &ndash; Redis/Memcached Server Entries](https://github.com/szepeviktor/w3-total-cache-fixed/pull/367) |
 :beetle: Bug Fix | [Undefined Variable: _is_amp_endpoint_](https://github.com/szepeviktor/w3-total-cache-fixed/pull/370) |
 :beetle: Bug Fix | [Error Message: _Trying to Get Property of Non-Object_](https://github.com/szepeviktor/w3-total-cache-fixed/pull/376) |
-:diamond_shape_with_a_dot_inside: Update | [Page Cache &ndash; _Accepted Query Strings_ Enhancement](https://github.com/szepeviktor/w3-total-cache-fixed/pull/380) |
+:diamond_shape_with_a_dot_inside: Update | [Page Cache &ndash; _Accepted Query Strings_ Enhancement](https://github.com/szepeviktor/w3-total-cache-fixed/pull/380)<br>:wrench: [+ **Extra: #PR489** &ndash; Fix all querystring keys starting with name specified will match](https://github.com/szepeviktor/w3-total-cache-fixed/pull/489) |
 :beetle: Bug Fix | [Incorrect Use of Removing Query String From URLs](https://github.com/szepeviktor/w3-total-cache-fixed/pull/382) |
 :diamond_shape_with_a_dot_inside: Update | [Enhance _remove_query()_ to Recognize Other Ampersand Forms](https://github.com/szepeviktor/w3-total-cache-fixed/pull/383) |
 :beetle: Bug Fix | [WP Query String Being Stripped Unexpectedly](https://github.com/szepeviktor/w3-total-cache-fixed/pull/384) |


### PR DESCRIPTION
This pr fix the issue where all querystring keys starting with name specified will match the accepted query strings.

If the user add the key `foo`, the rule all querystring keys starting with `foo`, eg.: `foobar`.

This happen because at line:
```php
$val .= ( strpos( $val, '=' ) === false ? '.*?' : '' );
```
the rule become 
`foo.*?`
instead of 
`foo=.*?`

the simple fix is add a `=` into the rule, eg.:
```php
$val .= ( strpos( $val, '=' ) === false ? '=.*?' : '' );
```
now, the rule become:
`foo=.*?`

Main PR is https://github.com/szepeviktor/w3-total-cache-fixed/pull/380