### PR TITLE
Fix page cache .htaccess for Windows

### DIFF
--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -703,7 +703,8 @@ class PgCache_Environment {
 			$env_W3TC_SSL = '%{ENV:W3TC_SSL}';
 		}
 
-		$cache_path = str_replace( Util_Environment::document_root(), '', $cache_dir );
+		$document_root = str_replace('\\', '/', Util_Environment::document_root());
+		$cache_path = str_replace($document_root, '', $cache_dir);
 
 		/**
 		 * Set Accept-Encoding

--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ Type | More Information |
 :beetle: Bug Fix | [Fixed wrong == in ObjectCache_WpObjectCache_Regular.php](https://github.com/szepeviktor/w3-total-cache-fixed/pull/486) |
 :beetle: Bug Fix | [Missing commas in Generic_Page_Dashboard_View.css](https://github.com/szepeviktor/w3-total-cache-fixed/pull/487) |
 :beetle: Bug Fix | [Remove uninitialized variable](https://github.com/szepeviktor/w3-total-cache-fixed/pull/488) |
+:beetle: Bug Fix | [Fix page cache .htaccess for Windows](https://github.com/szepeviktor/w3-total-cache-fixed/pull/490) |


### PR DESCRIPTION
On Windows OS the .htaccess section for page cache core module has a wrong path into the rule:

    RewriteCond "%{DOCUMENT_ROOT}C:/DevEnv/htdocs/www.wordpress.local/wp-content/cache/page_enhanced/%{HTTP_HOST}/%{REQUEST_URI}/_index%{ENV:W3TC_PREVIEW}.html%{ENV:W3TC_ENC}" -f

this happened because w3tc into the .htaccess generation for page cache rules works in a linux style only.

the fix is transform the windows path in a linux path style
```php
$document_root = str_replace('\\', '/', Util_Environment::document_root());
```
this fix the issue and now the rule is right:

    RewriteCond "%{DOCUMENT_ROOT}/wp-content/cache/page_enhanced/%{HTTP_HOST}/%{REQUEST_URI}/_index%{ENV:W3TC_PREVIEW}.html%{ENV:W3TC_ENC}" -f
    

    
