### PR TITLE
HTTP/2 Push: Fix collects headers from top directory

### DIFF
--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -116,13 +116,19 @@ class Cache_File_Generic extends Cache_File {
 				
 				if( !empty($links) ){
 					$rules .= "<IfModule mod_headers.c>\n";
+					$rules .= "    Header unset Link\n";
 					$rules .= $links;
 					$rules .= "</IfModule>\n";
 				}
 			}
 			
 			if( !empty($rules) ){
-				file_put_contents( dirname( $path ) . '/.htaccess', $rules);
+				$uri_cache_path  = dirname($path);
+				$base_cache_path = W3TC_CACHE_PAGE_ENHANCED_DIR . '/' . Util_Environment::host();
+				
+				if( $uri_cache_path != $base_cache_path ){
+				    @file_put_contents($uri_cache_path . '/.htaccess', $rules);
+				}
 			}
 		}
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Type | More Information |
 :beetle: Bug Fix | [YUI Compressor fix for JAVA path](https://github.com/szepeviktor/w3-total-cache-fixed/pull/426) |
 :beetle: Bug Fix | [Closure Compiler fix for JAVA path](https://github.com/szepeviktor/w3-total-cache-fixed/pull/428) |
 :beetle: Bug Fix | [Fixed Redis Test on Admin Dashboard](https://github.com/szepeviktor/w3-total-cache-fixed/pull/430) |
-:cyclone: New Feature | [Extends "http 2 push" to page cache enhanced](https://github.com/szepeviktor/w3-total-cache-fixed/pull/433)<br>:wrench: [+ **Extra: #PR320** &ndash; Support for more than 50 assets](https://github.com/szepeviktor/w3-total-cache-fixed/pull/450) |
+:cyclone: New Feature | [Extends "http 2 push" to page cache enhanced](https://github.com/szepeviktor/w3-total-cache-fixed/pull/433)<br>:wrench: [+ **Extra: #PR320** &ndash; Support for more than 50 assets](https://github.com/szepeviktor/w3-total-cache-fixed/pull/450)<br>:wrench: [+ **Extra: #PR491** &ndash; Fix collects headers from top directory](https://github.com/szepeviktor/w3-total-cache-fixed/pull/491) |
 :beetle: Bug Fix | [Fixed Object Cache setting cache value on missed gets](https://github.com/szepeviktor/w3-total-cache-fixed/issues/438) |
 :beetle: Bug Fix | [Call to a member function using_index_permalinks() on null](https://github.com/szepeviktor/w3-total-cache-fixed/issues/445) |
 :beetle: Bug Fix | [stristr(): Empty needle](https://github.com/szepeviktor/w3-total-cache-fixed/issues/447) |


### PR DESCRIPTION
This PR fix the issue, eg.: for page `/2017/05/23/my-post/` page it collects headers for all headers from `/`, `/2017/`, `/2017/05/`, `/2017/05/23/`, the `/2017/05/23/my-post/.htaccess` file causing 5 times more headers as a result with often redundant files to preload.

This PR also disable this feature for the home page because it break the cache.

