### PR TITLE
Fix Undefined property: W3TC\\Extension_Amp_Plugin::$is_amp_endpoint 

### DIFF
--- a/Extension_Amp_Plugin.php
+++ b/Extension_Amp_Plugin.php
@@ -3,7 +3,7 @@ namespace W3TC;
 
 class Extension_Amp_Plugin {
 	function __construct() {
-		$is_amp_endpoint = null;
+		
 	}
 
 	public function run() {
@@ -25,11 +25,12 @@ class Extension_Amp_Plugin {
 
 
 	private function is_amp_endpoint() {
-		if ( is_null( $this->is_amp_endpoint ) && function_exists('is_amp_endpoint') ) {
-			$this->is_amp_endpoint = is_amp_endpoint();
+		
+		if ( function_exists('is_amp_endpoint') ) {
+			return is_amp_endpoint();
 		}
 
-		return $this->is_amp_endpoint;
+		return false;
 	}
 
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ Type | More Information |
 :beetle: Bug Fix | [Missing commas in Generic_Page_Dashboard_View.css](https://github.com/szepeviktor/w3-total-cache-fixed/pull/487) |
 :beetle: Bug Fix | [Remove uninitialized variable](https://github.com/szepeviktor/w3-total-cache-fixed/pull/488) |
 :beetle: Bug Fix | [Fix page cache .htaccess for Windows](https://github.com/szepeviktor/w3-total-cache-fixed/pull/490) |
+:beetle: Bug Fix | [Fix Undefined property: W3TC\\Extension_Amp_Plugin::$is_amp_endpoint](https://github.com/szepeviktor/w3-total-cache-fixed/pull/510) |


### PR DESCRIPTION
> [Thu Jun 29 09:42:07.473748 2017] [:error] [pid 27221] [client 1.2.3.4:53172] PHP Notice: Undefined property: W3TC\\Extension_Amp_Plugin::$is_amp_endpoint in /wp-content/plugins/w3-total-cache/Extension_Amp_Plugin.php on line 28, referer: https://www.google.gr/

fix https://github.com/szepeviktor/w3-total-cache-fixed/issues/509