### PR TITLE
Unit Test

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,10 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/w3-total-cache.php';
 	update_option( 'active_plugins', 'w3-total-cache/w3-total-cache.php' );
+	
+	copy(W3TC_INSTALL_FILE_ADVANCED_CACHE, W3TC_ADDIN_FILE_ADVANCED_CACHE);
+	copy(W3TC_INSTALL_FILE_DB,             W3TC_ADDIN_FILE_DB);
+	copy(W3TC_INSTALL_FILE_OBJECT_CACHE,   W3TC_ADDIN_FILE_OBJECT_CACHE);
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,12 +17,11 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
+	copy('/tmp/wordpress/wp-content/plugins/w3-total-cache/wp-content/advanced-cache.php', '/tmp/wordpress/wp-content/advanced-cache.php');
+	copy('/tmp/wordpress/wp-content/plugins/w3-total-cache/wp-content/db.php',             '/tmp/wordpress/wp-content/db.php');
+	copy('/tmp/wordpress/wp-content/plugins/w3-total-cache/wp-content/object-cache.php',   '/tmp/wordpress/wp-content/object-cache.php');
+	
 	require dirname( dirname( __FILE__ ) ) . '/w3-total-cache.php';
-	
-	copy(W3TC_INSTALL_FILE_ADVANCED_CACHE, W3TC_ADDIN_FILE_ADVANCED_CACHE);
-	copy(W3TC_INSTALL_FILE_DB,             W3TC_ADDIN_FILE_DB);
-	copy(W3TC_INSTALL_FILE_OBJECT_CACHE,   W3TC_ADDIN_FILE_OBJECT_CACHE);
-	
 	update_option( 'active_plugins', 'w3-total-cache/w3-total-cache.php' );
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,11 +18,12 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/w3-total-cache.php';
-	update_option( 'active_plugins', 'w3-total-cache/w3-total-cache.php' );
 	
 	copy(W3TC_INSTALL_FILE_ADVANCED_CACHE, W3TC_ADDIN_FILE_ADVANCED_CACHE);
 	copy(W3TC_INSTALL_FILE_DB,             W3TC_ADDIN_FILE_DB);
 	copy(W3TC_INSTALL_FILE_OBJECT_CACHE,   W3TC_ADDIN_FILE_OBJECT_CACHE);
+	
+	update_option( 'active_plugins', 'w3-total-cache/w3-total-cache.php' );
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,16 +17,8 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	$plugin_dir  = dirname( dirname( __FILE__ ) );
-	$plugins_dir = dirname($plugin_dir);
-	$content_dir = dirname($plugins_dir);
-	
-	require $plugin_dir. '/w3-total-cache.php';
+	require dirname( dirname( __FILE__ ) ). '/w3-total-cache.php';
 	update_option( 'active_plugins', 'w3-total-cache/w3-total-cache.php' );
-	
-	copy($plugin_dir.'/wp-content/advanced-cache.php', $content_dir.'/advanced-cache.php');
-	copy($plugin_dir.'/wp-content/db.php',             $content_dir.'/db.php');
-	copy($plugin_dir.'/wp-content/object-cache.php',   $content_dir.'/object-cache.php');
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,14 +17,16 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	$plugin_dir = dirname( dirname( __FILE__ ) );
-	
-	copy($plugin_dir.'/wp-content/advanced-cache.php', '/tmp/wordpress/wp-content/advanced-cache.php');
-	copy($plugin_dir.'/wp-content/db.php',             '/tmp/wordpress/wp-content/db.php');
-	copy($plugin_dir.'/wp-content/object-cache.php',   '/tmp/wordpress/wp-content/object-cache.php');
+	$plugin_dir  = dirname( dirname( __FILE__ ) );
+	$plugins_dir = dirname($plugin_dir);
+	$content_dir = dirname($plugins_dir);
 	
 	require $plugin_dir. '/w3-total-cache.php';
 	update_option( 'active_plugins', 'w3-total-cache/w3-total-cache.php' );
+	
+	copy($plugin_dir.'/wp-content/advanced-cache.php', $content_dir.'/advanced-cache.php');
+	copy($plugin_dir.'/wp-content/db.php',             $content_dir.'/db.php');
+	copy($plugin_dir.'/wp-content/object-cache.php',   $content_dir.'/object-cache.php');
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,11 +17,13 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	copy('/tmp/wordpress/wp-content/plugins/w3-total-cache/wp-content/advanced-cache.php', '/tmp/wordpress/wp-content/advanced-cache.php');
-	copy('/tmp/wordpress/wp-content/plugins/w3-total-cache/wp-content/db.php',             '/tmp/wordpress/wp-content/db.php');
-	copy('/tmp/wordpress/wp-content/plugins/w3-total-cache/wp-content/object-cache.php',   '/tmp/wordpress/wp-content/object-cache.php');
+	$plugin_dir = dirname( dirname( __FILE__ ) );
 	
-	require dirname( dirname( __FILE__ ) ) . '/w3-total-cache.php';
+	copy($plugin_dir.'/wp-content/advanced-cache.php', '/tmp/wordpress/wp-content/advanced-cache.php');
+	copy($plugin_dir.'/wp-content/db.php',             '/tmp/wordpress/wp-content/db.php');
+	copy($plugin_dir.'/wp-content/object-cache.php',   '/tmp/wordpress/wp-content/object-cache.php');
+	
+	require $plugin_dir. '/w3-total-cache.php';
 	update_option( 'active_plugins', 'w3-total-cache/w3-total-cache.php' );
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/w3-object-cache-test.php
+++ b/tests/w3-object-cache-test.php
@@ -38,19 +38,6 @@ class W3_Object_Cache_Test extends WP_UnitTestCase {
 		$this->config = w3tc_config();
 		
 		$this->moduleStatus = \W3TC\Dispatcher::component( 'ModuleStatus' );
-		
-		// copy addin into wp-content ...
-		if( file_exists(W3TC_INSTALL_FILE_ADVANCED_CACHE) && !file_exists(W3TC_ADDIN_FILE_ADVANCED_CACHE) ){
-			copy(W3TC_INSTALL_FILE_ADVANCED_CACHE, W3TC_ADDIN_FILE_ADVANCED_CACHE);
-		}
-		
-		if( file_exists(W3TC_INSTALL_FILE_DB) && !file_exists(W3TC_ADDIN_FILE_DB) ){
-			copy(W3TC_INSTALL_FILE_DB, W3TC_ADDIN_FILE_DB);
-		}
-		
-		if( file_exists(W3TC_INSTALL_FILE_OBJECT_CACHE) && !file_exists(W3TC_ADDIN_FILE_OBJECT_CACHE) ){
-			copy(W3TC_INSTALL_FILE_OBJECT_CACHE,  W3TC_ADDIN_FILE_OBJECT_CACHE);
-		}
 	}
 	
 	/**

--- a/tests/w3-object-cache-test.php
+++ b/tests/w3-object-cache-test.php
@@ -38,6 +38,19 @@ class W3_Object_Cache_Test extends WP_UnitTestCase {
 		$this->config = w3tc_config();
 		
 		$this->moduleStatus = \W3TC\Dispatcher::component( 'ModuleStatus' );
+		
+		// copy addin into wp-content ...
+		if( file_exists(W3TC_INSTALL_FILE_ADVANCED_CACHE) && !file_exists(W3TC_ADDIN_FILE_ADVANCED_CACHE) ){
+			copy(W3TC_INSTALL_FILE_ADVANCED_CACHE, W3TC_ADDIN_FILE_ADVANCED_CACHE);
+		}
+		
+		if( file_exists(W3TC_INSTALL_FILE_DB) && !file_exists(W3TC_ADDIN_FILE_DB) ){
+			copy(W3TC_INSTALL_FILE_DB, W3TC_ADDIN_FILE_DB);
+		}
+		
+		if( file_exists(W3TC_INSTALL_FILE_OBJECT_CACHE) && !file_exists(W3TC_ADDIN_FILE_OBJECT_CACHE) ){
+			copy(W3TC_INSTALL_FILE_OBJECT_CACHE,  W3TC_ADDIN_FILE_OBJECT_CACHE);
+		}
 	}
 	
 	/**
@@ -73,15 +86,15 @@ class W3_Object_Cache_Test extends WP_UnitTestCase {
      */
     public function test_plugin_env()
     {
-	$WP_MULTISITE = getenv('WP_MULTISITE');
+	    $WP_MULTISITE = getenv('WP_MULTISITE');
 	    
-	$this->assertTrue( $WP_MULTISITE !== false );
+	    $this->assertTrue( $WP_MULTISITE !== false );
 	    
         if( is_multisite() ){
-	    $this->assertTrue( $WP_MULTISITE == 1 );
+	        $this->assertTrue( $WP_MULTISITE == 1 );
         } else {
-	    $this->assertTrue( $WP_MULTISITE == 0 );
-	}
+	        $this->assertTrue( $WP_MULTISITE == 0 );
+	    }
     }
 	
     /**

--- a/tests/w3-object-cache-test.php
+++ b/tests/w3-object-cache-test.php
@@ -76,6 +76,10 @@ class W3_Object_Cache_Test extends WP_UnitTestCase {
     function test_wp_cache() {
 	    $this->assertTrue( defined('WP_CACHE') && WP_CACHE === true );
 	    
+	    $this->assertTrue( defined('W3TC_ADDIN_FILE_ADVANCED_CACHE') );
+	    $this->assertTrue( defined('W3TC_ADDIN_FILE_DB') );
+	    $this->assertTrue( defined('W3TC_ADDIN_FILE_OBJECT_CACHE') );
+	    
 	    $this->assertTrue( file_exists(W3TC_ADDIN_FILE_ADVANCED_CACHE) );
 	    $this->assertTrue( file_exists(W3TC_ADDIN_FILE_DB) );
 	    $this->assertTrue( file_exists(W3TC_ADDIN_FILE_OBJECT_CACHE) );

--- a/tests/w3-object-cache-test.php
+++ b/tests/w3-object-cache-test.php
@@ -54,14 +54,18 @@ class W3_Object_Cache_Test extends WP_UnitTestCase {
      */
     function test_plugin_activation() {
         $this->assertTrue( is_plugin_active('w3-total-cache/w3-total-cache.php') );
-	$this->assertTrue( $this->moduleStatus->plugin_is_enabled() );
+	    $this->assertTrue( $this->moduleStatus->plugin_is_enabled() );
     }
 	
     /**
      * Check WP_CACHE
      */
     function test_wp_cache() {
-	$this->assertTrue( defined('WP_CACHE') && WP_CACHE === true );
+	    $this->assertTrue( defined('WP_CACHE') && WP_CACHE === true );
+	    
+	    $this->assertTrue( file_exists(W3TC_ADDIN_FILE_ADVANCED_CACHE) );
+	    $this->assertTrue( file_exists(W3TC_ADDIN_FILE_DB) );
+	    $this->assertTrue( file_exists(W3TC_ADDIN_FILE_OBJECT_CACHE) );
     }
  
     /**

--- a/tests/w3-object-cache-test.php
+++ b/tests/w3-object-cache-test.php
@@ -38,6 +38,19 @@ class W3_Object_Cache_Test extends WP_UnitTestCase {
 		$this->config = w3tc_config();
 		
 		$this->moduleStatus = \W3TC\Dispatcher::component( 'ModuleStatus' );
+		
+		// copy addin into wp-content ...
+		if( file_exists(W3TC_INSTALL_FILE_ADVANCED_CACHE) && !file_exists(W3TC_ADDIN_FILE_ADVANCED_CACHE) ){
+			copy(W3TC_INSTALL_FILE_ADVANCED_CACHE, W3TC_ADDIN_FILE_ADVANCED_CACHE);
+		}
+		
+		if( file_exists(W3TC_INSTALL_FILE_DB) && !file_exists(W3TC_ADDIN_FILE_DB) ){
+			copy(W3TC_INSTALL_FILE_DB, W3TC_ADDIN_FILE_DB);
+		}
+		
+		if( file_exists(W3TC_INSTALL_FILE_OBJECT_CACHE) && !file_exists(W3TC_ADDIN_FILE_OBJECT_CACHE) ){
+			copy(W3TC_INSTALL_FILE_OBJECT_CACHE,  W3TC_ADDIN_FILE_OBJECT_CACHE);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Enabling page cache causes errors in test, this happen because when the plugin is loaded into the wordpress test environment, this isn't correctly initialized.

But when the unit test start, all it's ok.

This pr add some extra check for insecure that during the test all is correctly.