### PR TITLE
Adjusting cdn link in MediaLibrary

### DIFF
--- a/Cdn_Plugin.php
+++ b/Cdn_Plugin.php
@@ -771,22 +771,22 @@ class Cdn_Plugin {
 	 * @return 	string
 	 */
     function w3tc_attachment_url( $url ) {
-        static $allowed_files = null;
-
-		if ( ( defined( 'WP_ADMIN' ) && $this->_config->get_boolean( 'cdn.admin.media_library' ) ) ||
-			 ( $this->can_cdn() && $this->can_cdn2( '' ) ) ) {
+		if ( defined( 'WP_ADMIN' ) && 
+			 $this->_config->get_boolean( 'cdn.admin.media_library' ) &&
+			 $this->_config->get_boolean( 'cdn.uploads.enable' ) && 
+			 $this->can_cdn2( '' )
+			) {
 			$url = trim( $url );
 
 			if ( !empty( $url ) ) {
-				if ( empty( $allowed_files ) ) {
-					$allowed_files = $this->get_files();
-				}
-
 				$parsed = parse_url( $url );
 				$rel_url = ( isset( $parsed['path'] ) ? $parsed['path'] : '/' ) .
 						   ( isset( $parsed['query'] ) ? '?' . $parsed['query'] : '' );
 
-				if ( in_array( ltrim( $rel_url, '/' ), $allowed_files ) ) {
+				//$uploadDir = wp_upload_dir()["basedir"];
+				$uploadDir = "/wp-content/uploads";
+				
+				if ( substr($parsed["path"], 0, strlen($uploadDir)) == $uploadDir ) {
 					$common = Dispatcher::component( 'Cdn_Core' );
 					$cdn = $common->get_cdn();
 					$remote_path = $common->uri_to_cdn_uri( $rel_url );

--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ Type | More Information |
 :beetle: Bug Fix | [Remove uninitialized variable](https://github.com/szepeviktor/w3-total-cache-fixed/pull/488) |
 :beetle: Bug Fix | [Fix page cache .htaccess for Windows](https://github.com/szepeviktor/w3-total-cache-fixed/pull/490) |
 :beetle: Bug Fix | [Fix Undefined property: W3TC\\Extension_Amp_Plugin::$is_amp_endpoint](https://github.com/szepeviktor/w3-total-cache-fixed/pull/510) |
+:beetle: Bug Fix | [Adjusting cdn link in MediaLibrary](https://github.com/szepeviktor/w3-total-cache-fixed/pull/516) |


### PR DESCRIPTION
Fixing the function w3tc_attachment_url.

#515 

The definition o w3tc_attachment_url (https://github.com/szepeviktor/w3-total-cache-fixed/blob/v0.9.5.x/Cdn_Plugin.php#L776) is wrong.

If idea is to work only in ADMIN, and cdn.admin.media_library=true, the if statement is wrong.