### PR TITLE
Add support for X-Forwarded-Proto to identify HTTPS protocol

### DIFF
--- a/PgCache_Environment.php
+++ b/PgCache_Environment.php
@@ -700,6 +700,8 @@ class PgCache_Environment {
 			$rules .= "    RewriteRule .* - [E=W3TC_SSL:_ssl]\n";
 			$rules .= "    RewriteCond %{SERVER_PORT} =443\n";
 			$rules .= "    RewriteRule .* - [E=W3TC_SSL:_ssl]\n";
+			$rules .= "    RewriteCond %{HTTP:X-Forwarded-Proto} =https [NC]\n";
+			$rules .= "    RewriteRule .* - [E=W3TC_SSL:_ssl]\n";
 			$env_W3TC_SSL = '%{ENV:W3TC_SSL}';
 		}
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Since the last [official release](https://wordpress.org/plugins/w3-total-cache/)
 
 Type | More Information |
 :--- | --- |
+:diamond_shape_with_a_dot_inside: Update | [Add support for X-Forwarded-Proto to identify HTTPS protocol](https://github.com/szepeviktor/w3-total-cache-fixed/pull/520) |
 :cyclone: New Feature | [Dashboard Widget For Flushing Individual User-Inputted URLs](https://github.com/szepeviktor/w3-total-cache-fixed/commit/f098003e8e4b4a3dbc2504b8a47b62205d5f6b9b)<br>:wrench: [+ **Extra: #PR335** &ndash; Adds Missing Nonce check](https://github.com/szepeviktor/w3-total-cache-fixed/pull/335) |
 :beetle: Bug Fix | [Gzipped Cached Pages Are Not Decoded Correctly &ndash; PHP 5.3.x Specific](https://github.com/szepeviktor/w3-total-cache-fixed/pull/313) |
 :beetle: Bug Fix | [_{uploads_dir}_ Placeholder & Full URLS Issue In CDN Custom Files Field](https://github.com/szepeviktor/w3-total-cache-fixed/pull/316) |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Since the last [official release](https://wordpress.org/plugins/w3-total-cache/)
 
 Type | More Information |
 :--- | --- |
-:diamond_shape_with_a_dot_inside: Update | [Add support for X-Forwarded-Proto to identify HTTPS protocol](https://github.com/szepeviktor/w3-total-cache-fixed/pull/520) |
 :cyclone: New Feature | [Dashboard Widget For Flushing Individual User-Inputted URLs](https://github.com/szepeviktor/w3-total-cache-fixed/commit/f098003e8e4b4a3dbc2504b8a47b62205d5f6b9b)<br>:wrench: [+ **Extra: #PR335** &ndash; Adds Missing Nonce check](https://github.com/szepeviktor/w3-total-cache-fixed/pull/335) |
 :beetle: Bug Fix | [Gzipped Cached Pages Are Not Decoded Correctly &ndash; PHP 5.3.x Specific](https://github.com/szepeviktor/w3-total-cache-fixed/pull/313) |
 :beetle: Bug Fix | [_{uploads_dir}_ Placeholder & Full URLS Issue In CDN Custom Files Field](https://github.com/szepeviktor/w3-total-cache-fixed/pull/316) |
@@ -96,3 +95,4 @@ Type | More Information |
 :beetle: Bug Fix | [Fix page cache .htaccess for Windows](https://github.com/szepeviktor/w3-total-cache-fixed/pull/490) |
 :beetle: Bug Fix | [Fix Undefined property: W3TC\\Extension_Amp_Plugin::$is_amp_endpoint](https://github.com/szepeviktor/w3-total-cache-fixed/pull/510) |
 :beetle: Bug Fix | [Adjusting cdn link in MediaLibrary](https://github.com/szepeviktor/w3-total-cache-fixed/pull/516) |
+:diamond_shape_with_a_dot_inside: Update | [Add support for X-Forwarded-Proto to identify HTTPS protocol](https://github.com/szepeviktor/w3-total-cache-fixed/pull/520) |


### PR DESCRIPTION
Support X-Forwarded-Proto header since it is used in some proxy or
load balancer environments to identify HTTPS protocol - nor HTTPS, 
nor SERVER_PORT variable is available in those scenarios to
identify the protocol used.

More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto