### PR TITLE
Return correct data from minify file cache when locking is in use

### DIFF
--- a/lib/Minify/Minify/Cache/File.php
+++ b/lib/Minify/Minify/Cache/File.php
@@ -152,7 +152,7 @@ class Minify_Cache_File {
 					@flock($fp, LOCK_UN);
 					@fclose($fp);
 
-					return $ret;
+					return array('content' => $ret);
 				}
 			} else {
 				$data['content'] = @file_get_contents($path);


### PR DESCRIPTION
The minify file cache was not functioning correctly when locking was
in use, because the code for fetching data from the cache was
returning the data itself, rather than an array with the data in its
'content' key.