### PR TITLE
Write correct data into minify cache file when cache dir is created

### DIFF
--- a/lib/Minify/Minify/Cache/File.php
+++ b/lib/Minify/Minify/Cache/File.php
@@ -48,7 +48,7 @@ class Minify_Cache_File {
 			// retry with make dir
 			\W3TC\Util_File::mkdir_from_safe(dirname($path), W3TC_CACHE_DIR);
 
-			if (!@file_put_contents($path, $data, $flag))
+			if (!@file_put_contents($path, $data['content'], $flag))
 				return false;
 		}
 


### PR DESCRIPTION
There was a bug in the code for detecting when the minify cache
directory does not exist while trying to save to a file in it,
creating it and attempting to save the file again. In this situation,
the wrong data would be saved into the cache file. This commit fixes
this problem.