### PR TITLE
Fix a timeout update that was missed in push CDN upload PR

### DIFF
--- a/Cdn_AdminActions.php
+++ b/Cdn_AdminActions.php
@@ -282,7 +282,7 @@ class Cdn_AdminActions {
 			$upload[] = $d;
 		}
 
-		$common->upload( $upload, false, $results, time() + 5 );
+		$common->upload( $upload, false, $results, time() + 120 );
 		$output = array();
 
 		foreach ( $results as $item ) {


### PR DESCRIPTION
An earlier PR, https://github.com/szepeviktor/w3-total-cache-fixed/pull/452,
Fixed several bugs in the code for uploading files to push CDNs,
including increasing timeouts for uploading chunks of files, since
five seconds wasn't nearly enough in many cases. Unfortunately, one of
the timeouts that needed to be increased was missed. This fixes that
missed timeout so it matches the others.