### PR TITLE
Write cache files in binary to prevent corruption of UTF-8 characters

### DIFF
--- a/Cache_File_Generic.php
+++ b/Cache_File_Generic.php
@@ -56,7 +56,7 @@ class Cache_File_Generic extends Cache_File {
 
 		$tmppath = $path . '.' . getmypid();
 
-		$fp = @fopen( $tmppath, 'w' );
+		$fp = @fopen( $tmppath, 'wb' );
 		if ( !$fp )
 			return false;
 
@@ -184,7 +184,7 @@ class Cache_File_Generic extends Cache_File {
 		if ( !is_readable( $path ) )
 			return null;
 
-		$fp = @fopen( $path, 'r' );
+		$fp = @fopen( $path, 'rb' );
 		if ( !$fp )
 			return null;
 

--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ Type | More Information |
 :beetle: Bug Fix | [Write correct data into minify cache file when cache dir is created](https://github.com/szepeviktor/w3-total-cache-fixed/pull/524) |
 :beetle: Bug Fix | [Make the Google Drive CDN work properly](https://github.com/szepeviktor/w3-total-cache-fixed/pull/523) |
 :beetle: Bug Fix | [Return correct data from minify file cache when locking is in use](https://github.com/szepeviktor/w3-total-cache-fixed/pull/522) |
+:beetle: Bug Fix | [Write cache files in binary to prevent corruption of UTF-8 characters](https://github.com/szepeviktor/w3-total-cache-fixed/pull/527) |


### PR DESCRIPTION
Some of my cached pages ended up with garbage characters in them. Turning off the page cache made the garbage characters go away. I looked at the page cache code, and it reads and writes cache files in ASCII mode, which corrupts UTF-8 characters in them. I modified the cache code to read and write cache files in binary. Simple change, should be innocuous, seems to solve the problem.