### PR TITLE
Fix object caching of arbitrary data within AJAX calls

### DIFF
--- a/ObjectCache_WpObjectCache_Regular.php
+++ b/ObjectCache_WpObjectCache_Regular.php
@@ -824,7 +824,7 @@ class ObjectCache_WpObjectCache_Regular {
 			$this->_can_cache_dynamic = true;
 		} else {
 			if ( $this->_caching ) {
-				if ( defined( 'WP_ADMIN' ) ) {
+				if ( defined( 'WP_ADMIN' ) && ( !defined('DOING_AJAX') || !DOING_AJAX ) ) {
 					$this->_can_cache_dynamic = false;
 					$this->cache_reject_reason = 'WP_ADMIN defined';
 					return $this->_can_cache_dynamic;

--- a/README.md
+++ b/README.md
@@ -102,3 +102,4 @@ Type | More Information |
 :beetle: Bug Fix | [Return correct data from minify file cache when locking is in use](https://github.com/szepeviktor/w3-total-cache-fixed/pull/522) |
 :beetle: Bug Fix | [Write cache files in binary to prevent corruption of UTF-8 characters](https://github.com/szepeviktor/w3-total-cache-fixed/pull/527) |
 :beetle: Bug Fix | [Fix error activating plugin by using MD5 hash rather than path for indexing Google Drive CDN files](https://github.com/szepeviktor/w3-total-cache-fixed/pull/532) |
+:beetle: Bug Fix | [Fix object caching within AJAX requests](https://github.com/szepeviktor/w3-total-cache-fixed/pull/537) |


### PR DESCRIPTION
Caching objects does not work when called with an AJAX request, unless the  “Enable caching for wp-admin requests” checkbox is ticked.
WP_ADMIN is defined and true for AJAX requests even when made on the front end, so this commit adds an extra check for the DOING_AJAX constant.

This PR is about being able to use `wp_cache_set()` _within_ AJAX requests.

Given the following crude example:

```php
add_action('wp_ajax_my_action', 'my_callback');
add_action('wp_ajax_nopriv_my_action', 'my_callback');
function my_callback()
{
    if (empty($_POST['thing'])) {
        wp_die('Thing must not be empty!');
    }

    wp_cache_set('my_key', $_POST['thing'], 'my_group');
    wp_die('Thing saved!');
}
```

Without this PR, the call to `wp_cache_set()` will fail and the item will NOT be saved in the cache under the key 'my_key', because the [ObjectCache_WpObjectCache_Regular::_check_can_cache_runtime()](https://github.com/andyexeter/w3-total-cache-fixed/blob/f33b509aec9c009ecf5b1276dd614859ae4b0c39/ObjectCache_WpObjectCache_Regular.php#L815) method returns false if the  “Enable caching for wp-admin requests” checkbox is unticked. This is due to the fact it currently only checks the `WP_ADMIN` which is set to true in AJAX requests.