### PR TITLE
Fix for "Fatal error: Uncaught exception 'Exception' with message 'unknown engine'"

### DIFF
--- a/Cdnfsd_CacheFlush.php
+++ b/Cdnfsd_CacheFlush.php
@@ -196,10 +196,10 @@ class Cdnfsd_CacheFlush {
 
 		if ( $o->flush_all_requested ) {
 			$core = Dispatcher::component( 'Cdnfsd_Core' );
-			$engine = $core->get_engine();
 
-		
 			try {
+				$engine = $core->get_engine();
+				
 				if ( !is_null( $engine ) ) {
 					$engine->flush_all();
 					$actions_made[] = array( 'module' => 'cdn' );
@@ -219,8 +219,10 @@ class Cdnfsd_CacheFlush {
 				$urls = array_keys( $o->queued_urls );
 
 				$core = Dispatcher::component( 'Cdnfsd_Core' );
-				$engine = $core->get_engine();
+				
 				try {
+					$engine = $core->get_engine();
+					
 					if ( !is_null( $engine ) ) {
 						$engine->flush_urls( $urls );
 						$actions_made[] = array( 'module' => 'cdn' );

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Since the last [official release](https://wordpress.org/plugins/w3-total-cache/)
 
 Type | More Information |
 :--- | --- |
+:beetle: Bug Fix | [Fix for "Fatal error: Uncaught exception 'Exception' with message 'unknown engine'"](https://github.com/szepeviktor/w3-total-cache-fixed/pull/553) |


### PR DESCRIPTION
From official forum https://wordpress.org/support/topic/fatal-error-2749/

`Fatal error: Uncaught exception ‘Exception’ with message ‘unknown engine ‘ in /home/swansph/public_html/wp-content/plugins/w3-total-cache/Cdnfsd_Core.php:48 Stack trace: #0 /home/swansph/public_html/wp-content/plugins/w3-total-cache/Cdnfsd_CacheFlush.php(222): W3TC\Cdnfsd_Core->get_engine() #1 [internal function]: W3TC\Cdnfsd_CacheFlush::w3tc_flush_execute_delayed_operations(Array) #2 /home/swansph/public_html/wp-includes/class-wp-hook.php(286): call_user_func_array(Array, Array) #3 /home/swansph/public_html/wp-includes/plugin.php(203): WP_Hook->apply_filters(Array, Array) #4 /home/swansph/public_html/wp-content/plugins/w3-total-cache/CacheFlush_Locally.php(253): apply_filters(‘w3tc_flush_exec…’, Array) #5 /home/swansph/public_html/wp-content/plugins/w3-total-cache/CacheFlush.php(188): W3TC\CacheFlush_Locally->execute_delayed_operations() #6 /home/swansph/public_html/wp-content/plugins/w3-total-cache/CacheFlush.php(194): W3TC\CacheFlush->execute_delayed_operations() #7 [internal function]: W3TC\CacheFlush->execute_delay in /home/swansph/public_html/wp-content/plugins/w3-total-cache/Cdnfsd_Core.php on line 48`