### PR TITLE
Fix undefined index minify

### DIFF
--- a/CacheFlush_Locally.php
+++ b/CacheFlush_Locally.php
@@ -81,7 +81,7 @@ class CacheFlush_Locally {
 	}
 
 	function minifycache_flush_all( $extras = array() ) {
-		if ( $extras['minify'] == 'purge_map' )
+		if ( isset( $extras['minify'] ) && $extras['minify'] == 'purge_map' )
 			delete_option( 'w3tc_minify' );
 
 		$this->minifycache_flush( $extras );

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Since the last [official release](https://wordpress.org/plugins/w3-total-cache/)
 Type | More Information |
 :--- | --- |
 :beetle: Bug Fix | [Fix for "Fatal error: Uncaught exception 'Exception' with message 'unknown engine'"](https://github.com/szepeviktor/w3-total-cache-fixed/pull/553) |
+:beetle: Bug Fix | [PHP Notice:  Undefined index: minify in CacheFlush_Locally.php](https://github.com/szepeviktor/w3-total-cache-fixed/pull/554) |


### PR DESCRIPTION
Fix for:

> [18-Jan-2018 19:24:46 UTC] PHP Notice:  Undefined index: minify in \wp-content\plugins\w3-total-cache\CacheFlush_Locally.php on line 84

on clean cache

