### PR TITLE
Validate needle passed to stristr function 

### DIFF
--- a/lib/Minify/Minify/IgnoredCommentPreserver.php
+++ b/lib/Minify/Minify/IgnoredCommentPreserver.php
@@ -39,7 +39,7 @@ class Minify_IgnoredCommentPreserver {
 
     protected function _isIgnoredComment(&$comment) {
         foreach ($this->_ignoredComments as $ignoredComment) {
-            if (stristr($comment, $ignoredComment) !== false) {
+            if (!empty($ignoredComment) && stristr($comment, $ignoredComment) !== false) {
                 return true;
             }
         }


### PR DESCRIPTION
Needle being passed to stristr is sometimes undefined, causing an error log entry. Validating the needle is not empty before calling the function fixes it. 
