### PR TITLE
Adding filters for SQL statements listing posts while preparing CDN.

### DIFF
--- a/Cdn_Core_Admin.php
+++ b/Cdn_Core_Admin.php
@@ -307,6 +307,8 @@ class Cdn_Core_Admin {
 				}
 			}
 
+            $sql = apply_filters('w3tc_cdn_import_library_sql', $sql);
+
 			$posts = $wpdb->get_results( $sql );
 
 			if ( $posts ) {
@@ -570,6 +572,8 @@ class Cdn_Core_Admin {
 				}
 			}
 
+            $sql = apply_filters('w3tc_cdn_rename_domain_posts_sql', $sql);
+
 			$posts = $wpdb->get_results( $sql );
 
 			if ( $posts ) {
@@ -645,6 +649,8 @@ WHERE p.post_type = "attachment" AND (pm.meta_value IS NOT NULL OR pm2.meta_valu
                 AND (post_content LIKE "%%src=%%"
                 	OR post_content LIKE "%%href=%%")
                 ', $wpdb->prefix );
+
+        $sql = apply_filters('w3tc_cdn_import_posts_count_sql', $sql);
 
 		return $wpdb->get_var( $sql );
 	}


### PR DESCRIPTION
When preparing the CDN and running such functions as _Modify attachment URLs_ or _Upload attachments_ these new filter hooks provide a way for manipulating the SQL statement fetching the posts. For instance adding more post types that might contain attachments moved to the CDN storage.

Filters 
* _w3tc_cdn_import_library_sql_ - Getting posts to import attachments to Media Library
* _w3tc_cdn_rename_domain_posts_sql_ - Getting posts that might contain posts with domain to be replaced
* _w3tc_cdn_import_posts_count_sql_ - Counting affected posts
