### PR TITLE
Update Cli.php

### DIFF
--- a/Cli.php
+++ b/Cli.php
@@ -580,7 +580,7 @@ class W3TotalCache_Command extends \WP_CLI_Command {
             \WP_CLI::error( __( 'Error: ' . $e->getMessage(), 'w3-total-cache' ) );
         }
     }        
-}
+
 
 
 if ( method_exists( '\WP_CLI', 'add_command' ) ) {


### PR DESCRIPTION
there is a syntax error on line 583 there is an extra '}'

This was flagging up when using wp-cli removing the extra } solves the issue


